### PR TITLE
Add push spread with randomize augment

### DIFF
--- a/src/main/java/com/github/ars_zero/common/glyph/PushEffect.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/PushEffect.java
@@ -12,6 +12,8 @@ import com.hollingsworth.arsnouveau.api.spell.SpellStats;
 import com.hollingsworth.arsnouveau.api.spell.SpellTier;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentRandomize;
+import net.minecraft.util.RandomSource;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -42,6 +44,10 @@ public class PushEffect extends AbstractEffect {
         }
         
         Vec3 lookVec = shooter.getLookAngle();
+        int randomizeLevel = spellStats.getBuffCount(AugmentRandomize.INSTANCE);
+        if (randomizeLevel > 0) {
+            lookVec = applySpread(lookVec, world.random, randomizeLevel);
+        }
         
         double baseStrength = 1.5;
         double strength = baseStrength + spellStats.getAmpMultiplier() * 0.5;
@@ -56,6 +62,13 @@ public class PushEffect extends AbstractEffect {
         world.playSound(null, shooter.getX(), shooter.getY(), shooter.getZ(), ModSounds.EFFECT_PUSH.get(), SoundSource.NEUTRAL, 1.0f, pitch);
     }
 
+    private Vec3 applySpread(Vec3 direction, RandomSource random, int randomizeLevel) {
+        float maxOffset = (float) Math.toRadians(randomizeLevel * 10.0);
+        float yawOffset = (random.nextFloat() * 2.0f - 1.0f) * maxOffset;
+        float pitchOffset = (random.nextFloat() * 2.0f - 1.0f) * maxOffset;
+        return direction.yRot(yawOffset).xRot(pitchOffset);
+    }
+
     @Override
     public int getDefaultManaCost() {
         return 25;
@@ -64,7 +77,7 @@ public class PushEffect extends AbstractEffect {
     @NotNull
     @Override
     public Set<AbstractAugment> getCompatibleAugments() {
-        return Set.of(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE);
+        return Set.of(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE, AugmentRandomize.INSTANCE);
     }
 
     @Override
@@ -72,6 +85,7 @@ public class PushEffect extends AbstractEffect {
         super.addAugmentDescriptions(map);
         map.put(AugmentAmplify.INSTANCE, "Increases the push strength");
         map.put(AugmentDampen.INSTANCE, "Decreases the push strength");
+        map.put(AugmentRandomize.INSTANCE, "Adds spread to the push direction");
     }
 
     @Override

--- a/src/main/resources/assets/ars_zero/lang/en_us.json
+++ b/src/main/resources/assets/ars_zero/lang/en_us.json
@@ -54,6 +54,7 @@
 
   "ars_nouveau.augment_desc.push_effect_glyph_amplify": "Increases the push strength",
   "ars_nouveau.augment_desc.push_effect_glyph_dampen": "Decreases the push strength",
+  "ars_nouveau.augment_desc.push_effect_glyph_randomize": "Adds 10 degrees of spread per Randomize augment",
 
   "ars_nouveau.augment_desc.translate_effect_glyph_amplify": "Increases the distance from the player",
   "ars_nouveau.augment_desc.translate_effect_glyph_dampen": "Decreases the distance from the player",


### PR DESCRIPTION
Add spread support to the Push glyph, allowing the Randomize augment to add +10 degrees of spread per level.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbe12567-e2c4-490d-87ba-cc10b06c5ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbe12567-e2c4-490d-87ba-cc10b06c5ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

