### PR TITLE
add: augment extract with push to alter target direction

### DIFF
--- a/src/main/java/com/github/ars_zero/common/glyph/PushEffect.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/PushEffect.java
@@ -14,6 +14,7 @@ import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtract;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentRandomize;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.Entity;
@@ -112,6 +113,11 @@ public class PushEffect extends AbstractEffect {
     @Override
     public Set<SpellSchool> getSchools() {
         return Set.of(SpellSchools.ELEMENTAL_AIR);
+    }
+
+    @Override
+    protected void addDefaultAugmentLimits(Map<ResourceLocation, Integer> defaults) {
+        defaults.put(AugmentExtract.INSTANCE.getRegistryName(), 1);
     }
 }
 

--- a/src/main/java/com/github/ars_zero/common/glyph/PushEffect.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/PushEffect.java
@@ -12,8 +12,8 @@ import com.hollingsworth.arsnouveau.api.spell.SpellStats;
 import com.hollingsworth.arsnouveau.api.spell.SpellTier;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtract;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentRandomize;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSensitive;
 import net.minecraft.util.RandomSource;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.Entity;
@@ -45,7 +45,7 @@ public class PushEffect extends AbstractEffect {
         }
         
         Vec3 pushDirection;
-        if (spellStats.isSensitive()) {
+        if (spellStats.getBuffCount(AugmentExtract.INSTANCE) > 0) {
             Vec3 casterPos = shooter.position().add(0, shooter.getEyeHeight(), 0);
             Vec3 targetPos = target.position().add(0, target.getBbHeight() / 2, 0);
             pushDirection = targetPos.subtract(casterPos).normalize();
@@ -86,7 +86,7 @@ public class PushEffect extends AbstractEffect {
     @NotNull
     @Override
     public Set<AbstractAugment> getCompatibleAugments() {
-        return Set.of(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE, AugmentRandomize.INSTANCE, AugmentSensitive.INSTANCE);
+        return Set.of(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE, AugmentRandomize.INSTANCE, AugmentExtract.INSTANCE);
     }
 
     @Override
@@ -95,7 +95,7 @@ public class PushEffect extends AbstractEffect {
         map.put(AugmentAmplify.INSTANCE, "Increases the push strength");
         map.put(AugmentDampen.INSTANCE, "Decreases the push strength");
         map.put(AugmentRandomize.INSTANCE, "Adds spread to the push direction");
-        map.put(AugmentSensitive.INSTANCE, "Pushes from the direction between caster and target entity");
+        map.put(AugmentExtract.INSTANCE, "Pushes from the direction between caster and target entity");
     }
 
     @Override

--- a/src/main/resources/assets/ars_zero/lang/en_us.json
+++ b/src/main/resources/assets/ars_zero/lang/en_us.json
@@ -78,7 +78,7 @@
   "ars_nouveau.augment_desc.push_effect_glyph_amplify": "Increases the push strength",
   "ars_nouveau.augment_desc.push_effect_glyph_dampen": "Decreases the push strength",
   "ars_nouveau.augment_desc.push_effect_glyph_randomize": "Adds 10 degrees of spread per Randomize augment",
-  "ars_nouveau.augment_desc.push_effect_glyph_sensitive": "Pushes from the direction between caster and target entity",
+  "ars_nouveau.augment_desc.push_effect_glyph_extract": "Pushes from the direction between caster and target entity",
 
   "ars_nouveau.augment_desc.anchor_effect_glyph_amplify": "Increases the distance from the player",
   "ars_nouveau.augment_desc.anchor_effect_glyph_dampen": "Decreases the distance from the player",

--- a/src/main/resources/assets/ars_zero/lang/en_us.json
+++ b/src/main/resources/assets/ars_zero/lang/en_us.json
@@ -78,6 +78,7 @@
   "ars_nouveau.augment_desc.push_effect_glyph_amplify": "Increases the push strength",
   "ars_nouveau.augment_desc.push_effect_glyph_dampen": "Decreases the push strength",
   "ars_nouveau.augment_desc.push_effect_glyph_randomize": "Adds 10 degrees of spread per Randomize augment",
+  "ars_nouveau.augment_desc.push_effect_glyph_sensitive": "Pushes from the direction between caster and target entity",
 
   "ars_nouveau.augment_desc.anchor_effect_glyph_amplify": "Increases the distance from the player",
   "ars_nouveau.augment_desc.anchor_effect_glyph_dampen": "Decreases the distance from the player",


### PR DESCRIPTION
Add `AugmentSensitive` support to the Push effect to push entities from the direction between the caster and the target instead of the caster's look direction.

---
<a href="https://cursor.com/background-agent?bcId=bc-43164f39-ab48-411e-a629-98e85307d2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43164f39-ab48-411e-a629-98e85307d2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

