### PR TITLE
Fix spell name display

### DIFF
--- a/src/main/java/com/github/ars_zero/client/gui/GuiStaffHUD.java
+++ b/src/main/java/com/github/ars_zero/client/gui/GuiStaffHUD.java
@@ -27,9 +27,17 @@ public class GuiStaffHUD {
             AbstractCaster<?> caster = SpellCasterRegistry.from(stack);
             
             int logicalSlot = caster.getCurrentSlot();
+            int beginPhysicalSlot = logicalSlot * 3 + 0;
             int tickPhysicalSlot = logicalSlot * 3 + 1;
+            int endPhysicalSlot = logicalSlot * 3 + 2;
             
             String spellName = caster.getSpellName(tickPhysicalSlot);
+            if (spellName.isEmpty()) {
+                spellName = caster.getSpellName(beginPhysicalSlot);
+            }
+            if (spellName.isEmpty()) {
+                spellName = caster.getSpellName(endPhysicalSlot);
+            }
             String renderString = (logicalSlot + 1) + " " + spellName;
             
             graphics.drawString(

--- a/src/main/java/com/github/ars_zero/client/gui/GuiStaffHUD.java
+++ b/src/main/java/com/github/ars_zero/client/gui/GuiStaffHUD.java
@@ -11,6 +11,8 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.LayeredDraw;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.Arrays;
+
 public class GuiStaffHUD {
     public static final LayeredDraw.Layer OVERLAY = GuiStaffHUD::renderOverlay;
 
@@ -27,17 +29,18 @@ public class GuiStaffHUD {
             AbstractCaster<?> caster = SpellCasterRegistry.from(stack);
             
             int logicalSlot = caster.getCurrentSlot();
-            int beginPhysicalSlot = logicalSlot * 3 + 0;
-            int tickPhysicalSlot = logicalSlot * 3 + 1;
-            int endPhysicalSlot = logicalSlot * 3 + 2;
+            int[] physicalSlots = {
+                logicalSlot * 3 + 0,
+                logicalSlot * 3 + 1,
+                logicalSlot * 3 + 2
+            };
             
-            String spellName = caster.getSpellName(tickPhysicalSlot);
-            if (spellName.isEmpty()) {
-                spellName = caster.getSpellName(beginPhysicalSlot);
-            }
-            if (spellName.isEmpty()) {
-                spellName = caster.getSpellName(endPhysicalSlot);
-            }
+            String spellName = Arrays.stream(physicalSlots)
+                .mapToObj(caster::getSpellName)
+                .filter(name -> !name.isEmpty())
+                .findFirst()
+                .orElse("");
+            
             String renderString = (logicalSlot + 1) + " " + spellName;
             
             graphics.drawString(

--- a/src/main/java/com/github/ars_zero/common/item/AbstractMultiPhaseCastDevice.java
+++ b/src/main/java/com/github/ars_zero/common/item/AbstractMultiPhaseCastDevice.java
@@ -189,23 +189,64 @@ public abstract class AbstractMultiPhaseCastDevice extends Item implements ICast
         List<RadialMenuSlot<AbstractSpellPart>> radialMenuSlots = new ArrayList<>();
 
         for (int logicalSlot = 0; logicalSlot < 10; logicalSlot++) {
+            int beginPhysicalSlot = logicalSlot * 3 + SpellPhase.BEGIN.ordinal();
             int tickPhysicalSlot = logicalSlot * 3 + SpellPhase.TICK.ordinal();
-            Spell spell = spellCaster.getSpell(tickPhysicalSlot);
-
-            if (!spell.isEmpty()) {
-                AbstractSpellPart iconGlyph = null;
-                for (AbstractSpellPart part : spell.recipe()) {
+            int endPhysicalSlot = logicalSlot * 3 + SpellPhase.END.ordinal();
+            
+            Spell beginSpell = spellCaster.getSpell(beginPhysicalSlot);
+            Spell tickSpell = spellCaster.getSpell(tickPhysicalSlot);
+            Spell endSpell = spellCaster.getSpell(endPhysicalSlot);
+            
+            String spellName = "";
+            AbstractSpellPart iconGlyph = null;
+            
+            if (!tickSpell.isEmpty()) {
+                spellName = spellCaster.getSpellName(tickPhysicalSlot);
+                for (AbstractSpellPart part : tickSpell.recipe()) {
                     if (!(part instanceof AbstractCastMethod)) {
                         iconGlyph = part;
                         break;
                     }
                 }
-                if (iconGlyph == null && spell.recipe().iterator().hasNext()) {
-                    iconGlyph = spell.recipe().iterator().next();
+                if (iconGlyph == null && tickSpell.recipe().iterator().hasNext()) {
+                    iconGlyph = tickSpell.recipe().iterator().next();
                 }
-                radialMenuSlots.add(new RadialMenuSlot<>(spellCaster.getSpellName(tickPhysicalSlot), iconGlyph));
+            } else if (!beginSpell.isEmpty()) {
+                spellName = spellCaster.getSpellName(beginPhysicalSlot);
+                for (AbstractSpellPart part : beginSpell.recipe()) {
+                    if (!(part instanceof AbstractCastMethod)) {
+                        iconGlyph = part;
+                        break;
+                    }
+                }
+                if (iconGlyph == null && beginSpell.recipe().iterator().hasNext()) {
+                    iconGlyph = beginSpell.recipe().iterator().next();
+                }
+            } else if (!endSpell.isEmpty()) {
+                spellName = spellCaster.getSpellName(endPhysicalSlot);
+                for (AbstractSpellPart part : endSpell.recipe()) {
+                    if (!(part instanceof AbstractCastMethod)) {
+                        iconGlyph = part;
+                        break;
+                    }
+                }
+                if (iconGlyph == null && endSpell.recipe().iterator().hasNext()) {
+                    iconGlyph = endSpell.recipe().iterator().next();
+                }
             } else {
+                spellName = spellCaster.getSpellName(tickPhysicalSlot);
+                if (spellName.isEmpty()) {
+                    spellName = spellCaster.getSpellName(beginPhysicalSlot);
+                }
+                if (spellName.isEmpty()) {
+                    spellName = spellCaster.getSpellName(endPhysicalSlot);
+                }
+            }
+            
+            if (spellName.isEmpty()) {
                 radialMenuSlots.add(new RadialMenuSlot<>("Empty", null));
+            } else {
+                radialMenuSlots.add(new RadialMenuSlot<>(spellName, iconGlyph));
             }
         }
         return radialMenuSlots;


### PR DESCRIPTION
Display spell names in the radial menu and HUD even if the 'tick' spell slot is empty, by checking all three spell phase slots.

The previous implementation for the radial menu and HUD only retrieved the spell name from the 'tick' phase slot. This caused spells without a 'tick' component to display as "Empty" in the UI, despite their names being correctly saved in the 'begin' or 'end' phase slots. This change updates the display logic to prioritize the 'tick' slot, then 'begin', then 'end' for retrieving the spell name and icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-d80ed100-9189-4766-93c1-d0a62f7cd637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d80ed100-9189-4766-93c1-d0a62f7cd637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

