### PR TITLE
Adjust log levels for dev

### DIFF
--- a/src/main/java/com/github/ars_zero/client/gui/AbstractMultiPhaseCastDeviceScreen.java
+++ b/src/main/java/com/github/ars_zero/client/gui/AbstractMultiPhaseCastDeviceScreen.java
@@ -365,7 +365,7 @@ public abstract class AbstractMultiPhaseCastDeviceScreen extends SpellSlottedScr
         addRenderableWidget(spellNameBox);
 
         addRenderableWidget(new CreateSpellButton(bookRight - 84, bookBottom - 29, (b) -> {
-            ArsZero.LOGGER.info("Save button clicked!");
+            ArsZero.LOGGER.debug("Save button clicked!");
             this.saveSpell();
         }, this::getValidationErrors));
         addRenderableWidget(new ClearButton(bookRight - 137, bookBottom - 29, Component.translatable("ars_nouveau.spell_book_gui.clear"), (button) -> clear()));
@@ -1012,10 +1012,10 @@ public abstract class AbstractMultiPhaseCastDeviceScreen extends SpellSlottedScr
     }
     
     private void renderManaIndicators(GuiGraphics graphics, int mouseX, int mouseY) {
-        ArsZero.LOGGER.info("=== MANA INDICATOR RENDER START ===");
-        ArsZero.LOGGER.info("bookLeft: {}, bookTop: {}", bookLeft, bookTop);
-        ArsZero.LOGGER.info("PHASE_SECTION_SHIFT_X: {}, PHASE_ROW_TEXTURE_X_OFFSET: {}", PHASE_SECTION_SHIFT_X, PHASE_ROW_TEXTURE_X_OFFSET);
-        ArsZero.LOGGER.info("PHASE_ROW_TEXTURE_WIDTH: {}", PHASE_ROW_TEXTURE_WIDTH);
+        ArsZero.LOGGER.debug("=== MANA INDICATOR RENDER START ===");
+        ArsZero.LOGGER.debug("bookLeft: {}, bookTop: {}", bookLeft, bookTop);
+        ArsZero.LOGGER.debug("PHASE_SECTION_SHIFT_X: {}, PHASE_ROW_TEXTURE_X_OFFSET: {}", PHASE_SECTION_SHIFT_X, PHASE_ROW_TEXTURE_X_OFFSET);
+        ArsZero.LOGGER.debug("PHASE_ROW_TEXTURE_WIDTH: {}", PHASE_ROW_TEXTURE_WIDTH);
         
         int phaseRowStartX = bookLeft + PHASE_ROW_TEXTURE_X_OFFSET + PHASE_SECTION_SHIFT_X - 4;
         int phaseRowEndX = phaseRowStartX + PHASE_ROW_TEXTURE_WIDTH;
@@ -1024,9 +1024,9 @@ public abstract class AbstractMultiPhaseCastDeviceScreen extends SpellSlottedScr
         int rowHeight = PHASE_ROW_HEIGHT + 2;
         int indicatorHeight = 14;
         
-        ArsZero.LOGGER.info("Phase row start X: {}, end X: {}", phaseRowStartX, phaseRowEndX);
-        ArsZero.LOGGER.info("Indicator X: {}, baseY: {}", indicatorX, baseY);
-        ArsZero.LOGGER.info("Player: {}", player != null ? player.getName().getString() : "NULL");
+        ArsZero.LOGGER.debug("Phase row start X: {}, end X: {}", phaseRowStartX, phaseRowEndX);
+        ArsZero.LOGGER.debug("Indicator X: {}, baseY: {}", indicatorX, baseY);
+        ArsZero.LOGGER.debug("Player: {}", player != null ? player.getName().getString() : "NULL");
         
         ManaIndicator hoveredIndicator = null;
         
@@ -1035,16 +1035,16 @@ public abstract class AbstractMultiPhaseCastDeviceScreen extends SpellSlottedScr
             List<AbstractSpellPart> phaseSpell = phaseSpells.getPhaseList(phase);
             int indicatorY = baseY + phaseIndex * rowHeight + (PHASE_ROW_HEIGHT - indicatorHeight) / 2 - 1 + 1;
             
-            ArsZero.LOGGER.info("Phase {}: indicatorY={}, spell parts count={}", phase, indicatorY, phaseSpell.size());
+            ArsZero.LOGGER.debug("Phase {}: indicatorY={}, spell parts count={}", phase, indicatorY, phaseSpell.size());
             
             ManaIndicator indicator = new ManaIndicator(indicatorX, indicatorY, phaseSpell);
             indicator.render(graphics, player);
             
-            ArsZero.LOGGER.info("Phase {}: After render call", phase);
+            ArsZero.LOGGER.debug("Phase {}: After render call", phase);
             
             if (indicator.isHovered(mouseX, mouseY)) {
                 hoveredIndicator = indicator;
-                ArsZero.LOGGER.info("Phase {}: HOVERED! mouseX={}, mouseY={}", phase, mouseX, mouseY);
+                ArsZero.LOGGER.debug("Phase {}: HOVERED! mouseX={}, mouseY={}", phase, mouseX, mouseY);
             }
             phaseIndex++;
         }
@@ -1053,7 +1053,7 @@ public abstract class AbstractMultiPhaseCastDeviceScreen extends SpellSlottedScr
             hoveredIndicator.renderTooltip(graphics, mouseX, mouseY);
         }
         
-        ArsZero.LOGGER.info("=== MANA INDICATOR RENDER END ===");
+        ArsZero.LOGGER.debug("=== MANA INDICATOR RENDER END ===");
     }
     
     private void refreshCategoryButtons() {

--- a/src/main/java/com/github/ars_zero/client/gui/buttons/ManaIndicator.java
+++ b/src/main/java/com/github/ars_zero/client/gui/buttons/ManaIndicator.java
@@ -28,19 +28,19 @@ public class ManaIndicator {
         this.x = x;
         this.y = y;
         this.phaseSpell = phaseSpell;
-        ArsZero.LOGGER.info("ManaIndicator created: x={}, y={}, spell parts={}", x, y, phaseSpell.size());
+        ArsZero.LOGGER.debug("ManaIndicator created: x={}, y={}, spell parts={}", x, y, phaseSpell.size());
     }
     
     public void render(GuiGraphics graphics, Player player) {
-        ArsZero.LOGGER.info("ManaIndicator.render() called: x={}, y={}, player={}", x, y, player != null ? player.getName().getString() : "NULL");
+        ArsZero.LOGGER.debug("ManaIndicator.render() called: x={}, y={}, player={}", x, y, player != null ? player.getName().getString() : "NULL");
         
         int screenWidth = Minecraft.getInstance().getWindow().getGuiScaledWidth();
         int screenHeight = Minecraft.getInstance().getWindow().getGuiScaledHeight();
-        ArsZero.LOGGER.info("ManaIndicator: Screen dimensions: {}x{}", screenWidth, screenHeight);
-        ArsZero.LOGGER.info("ManaIndicator: Indicator bounds: x=[{}, {}], y=[{}, {}]", x, x + INDICATOR_WIDTH, y, y + INDICATOR_HEIGHT);
+        ArsZero.LOGGER.debug("ManaIndicator: Screen dimensions: {}x{}", screenWidth, screenHeight);
+        ArsZero.LOGGER.debug("ManaIndicator: Indicator bounds: x=[{}, {}], y=[{}, {}]", x, x + INDICATOR_WIDTH, y, y + INDICATOR_HEIGHT);
         
         boolean inBounds = x >= 0 && x < screenWidth && y >= 0 && y < screenHeight;
-        ArsZero.LOGGER.info("ManaIndicator: In screen bounds: {}", inBounds);
+        ArsZero.LOGGER.debug("ManaIndicator: In screen bounds: {}", inBounds);
         
         IManaCap manaCap = CapabilityRegistry.getMana(player);
         if (manaCap == null) {
@@ -51,7 +51,7 @@ public class ManaIndicator {
         }
         
         double maxMana = manaCap.getMaxMana();
-        ArsZero.LOGGER.info("ManaIndicator: maxMana={}", maxMana);
+        ArsZero.LOGGER.debug("ManaIndicator: maxMana={}", maxMana);
         if (maxMana <= 0) {
             ArsZero.LOGGER.warn("ManaIndicator: maxMana <= 0, drawing debug indicator");
             graphics.fill(x - 1, y - 1, x + INDICATOR_WIDTH + 1, y + INDICATOR_HEIGHT + 1, 0xFFFF0000);
@@ -60,7 +60,7 @@ public class ManaIndicator {
         }
         
         int spellCost = calculatePhaseManaCost();
-        ArsZero.LOGGER.info("ManaIndicator: spellCost={}", spellCost);
+        ArsZero.LOGGER.debug("ManaIndicator: spellCost={}", spellCost);
         double fillRatio = Math.min(spellCost / maxMana, 1.0);
         int fillHeight = (int) (INDICATOR_HEIGHT * fillRatio);
         
@@ -68,19 +68,19 @@ public class ManaIndicator {
             fillHeight = 1;
         }
         
-        ArsZero.LOGGER.info("ManaIndicator: fillRatio={}, fillHeight={}", fillRatio, fillHeight);
+        ArsZero.LOGGER.debug("ManaIndicator: fillRatio={}, fillHeight={}", fillRatio, fillHeight);
         
         if (fillHeight > 0) {
             int fillY = y + INDICATOR_HEIGHT - fillHeight;
-            ArsZero.LOGGER.info("ManaIndicator: Drawing fill at x={}, y={} to x={}, y={}, color=0x{:08X}", x, fillY, x + INDICATOR_WIDTH, y + INDICATOR_HEIGHT, MANA_COLOR);
+            ArsZero.LOGGER.debug("ManaIndicator: Drawing fill at x={}, y={} to x={}, y={}, color=0x{:08X}", x, fillY, x + INDICATOR_WIDTH, y + INDICATOR_HEIGHT, MANA_COLOR);
             graphics.fill(x, fillY, x + INDICATOR_WIDTH, y + INDICATOR_HEIGHT, MANA_COLOR);
-            ArsZero.LOGGER.info("ManaIndicator: Fill drawn successfully");
+            ArsZero.LOGGER.debug("ManaIndicator: Fill drawn successfully");
         } else {
             ArsZero.LOGGER.warn("ManaIndicator: fillHeight is 0, drawing empty indicator");
             graphics.fill(x, y, x + INDICATOR_WIDTH, y + INDICATOR_HEIGHT, 0x33C67EDE);
         }
         
-        ArsZero.LOGGER.info("ManaIndicator.render() completed");
+        ArsZero.LOGGER.debug("ManaIndicator.render() completed");
     }
     
     public boolean isHovered(int mouseX, int mouseY) {

--- a/src/main/java/com/github/ars_zero/common/network/PacketAdjustStaffDistance.java
+++ b/src/main/java/com/github/ars_zero/common/network/PacketAdjustStaffDistance.java
@@ -62,7 +62,7 @@ public record PacketAdjustStaffDistance(double scrollDelta) implements CustomPac
                 double oldMultiplier = castContext.distanceMultiplier;
                 castContext.distanceMultiplier += multiplierChange;
                 
-                ArsZero.LOGGER.info("Scroll: voxelSize={}, scrollDelta={}, sensitivity={}, multiplierChange={}, distanceMultiplier: {} -> {}", 
+                ArsZero.LOGGER.debug("Scroll: voxelSize={}, scrollDelta={}, sensitivity={}, multiplierChange={}, distanceMultiplier: {} -> {}", 
                     entitySize, packet.scrollDelta, scrollSensitivity, multiplierChange, oldMultiplier, castContext.distanceMultiplier);
                 
                 castContext.distanceMultiplier = Math.max(MIN_DISTANCE_MULTIPLIER, 

--- a/src/main/java/com/github/ars_zero/event/ModEventHandlers.java
+++ b/src/main/java/com/github/ars_zero/event/ModEventHandlers.java
@@ -16,10 +16,10 @@ public class ModEventHandlers {
         // This event fires every tick for each player
         // We only need to register once, so we'll use a static flag
         if (!ModItems.SPELL_CASTERS_REGISTERED) {
-            ArsZero.LOGGER.info("PlayerTick event fired - registering spell casters with Ars Nouveau...");
+            ArsZero.LOGGER.debug("PlayerTick event fired - registering spell casters with Ars Nouveau...");
             ModItems.registerSpellCasters();
             ModItems.SPELL_CASTERS_REGISTERED = true;
-            ArsZero.LOGGER.info("Spell caster registration completed");
+            ArsZero.LOGGER.debug("Spell caster registration completed");
         }
     }
 }

--- a/src/main/java/com/github/ars_zero/registry/ModBlockEntities.java
+++ b/src/main/java/com/github/ars_zero/registry/ModBlockEntities.java
@@ -29,12 +29,12 @@ public class ModBlockEntities {
     public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<MultiphaseSpellTurretTile>> MULTIPHASE_SPELL_TURRET = BLOCK_ENTITIES.register(
         "multiphase_spell_turret",
         () -> {
-            ArsZero.LOGGER.info("Registering Multiphase Spell Turret block entity type");
+            ArsZero.LOGGER.debug("Registering Multiphase Spell Turret block entity type");
             BlockEntityType<MultiphaseSpellTurretTile> type = BlockEntityType.Builder.of(
                 MultiphaseSpellTurretTile::new,
                 ModBlocks.MULTIPHASE_SPELL_TURRET.get()
             ).build(null);
-            ArsZero.LOGGER.info("Multiphase Spell Turret block entity type created successfully");
+            ArsZero.LOGGER.debug("Multiphase Spell Turret block entity type created successfully");
             return type;
         }
     );

--- a/src/main/java/com/github/ars_zero/registry/ModBlocks.java
+++ b/src/main/java/com/github/ars_zero/registry/ModBlocks.java
@@ -65,11 +65,11 @@ public class ModBlocks {
     public static final DeferredHolder<Block, MultiphaseSpellTurret> MULTIPHASE_SPELL_TURRET = BLOCKS.register(
         "multiphase_spell_turret",
         () -> {
-            ArsZero.LOGGER.info("Registering Multiphase Spell Turret block");
+            ArsZero.LOGGER.debug("Registering Multiphase Spell Turret block");
             MultiphaseSpellTurret block = new MultiphaseSpellTurret(BlockBehaviour.Properties.of()
                 .strength(2.0f)
                 .noOcclusion());
-            ArsZero.LOGGER.info("Multiphase Spell Turret block created successfully");
+            ArsZero.LOGGER.debug("Multiphase Spell Turret block created successfully");
             return block;
         }
     );

--- a/src/main/java/com/github/ars_zero/registry/ModGlyphs.java
+++ b/src/main/java/com/github/ars_zero/registry/ModGlyphs.java
@@ -25,31 +25,31 @@ public class ModGlyphs {
         
         ArsZero.LOGGER.debug("Registering TemporalContextForm glyph...");
         GlyphRegistry.registerSpell(TEMPORAL_CONTEXT_FORM);
-        ArsZero.LOGGER.info("Successfully registered TemporalContextForm glyph with ID: {}", TEMPORAL_CONTEXT_FORM.getRegistryName());
+        ArsZero.LOGGER.debug("Successfully registered TemporalContextForm glyph with ID: {}", TEMPORAL_CONTEXT_FORM.getRegistryName());
         
         ArsZero.LOGGER.debug("Registering NearForm glyph...");
         GlyphRegistry.registerSpell(NEAR_FORM);
-        ArsZero.LOGGER.info("Successfully registered NearForm glyph with ID: {}", NEAR_FORM.getRegistryName());
+        ArsZero.LOGGER.debug("Successfully registered NearForm glyph with ID: {}", NEAR_FORM.getRegistryName());
         
         ArsZero.LOGGER.debug("Registering ConjureVoxelEffect glyph...");
         GlyphRegistry.registerSpell(CONJURE_VOXEL_EFFECT);
-        ArsZero.LOGGER.info("Successfully registered ConjureVoxelEffect glyph with ID: {}", CONJURE_VOXEL_EFFECT.getRegistryName());
+        ArsZero.LOGGER.debug("Successfully registered ConjureVoxelEffect glyph with ID: {}", CONJURE_VOXEL_EFFECT.getRegistryName());
         
         ArsZero.LOGGER.debug("Registering SelectEffect glyph...");
         GlyphRegistry.registerSpell(SELECT_EFFECT);
-        ArsZero.LOGGER.info("Successfully registered SelectEffect glyph with ID: {}", SELECT_EFFECT.getRegistryName());
+        ArsZero.LOGGER.debug("Successfully registered SelectEffect glyph with ID: {}", SELECT_EFFECT.getRegistryName());
         
         ArsZero.LOGGER.debug("Registering AnchorEffect glyph...");
         GlyphRegistry.registerSpell(ANCHOR_EFFECT);
-        ArsZero.LOGGER.info("Successfully registered AnchorEffect glyph with ID: {}", ANCHOR_EFFECT.getRegistryName());
+        ArsZero.LOGGER.debug("Successfully registered AnchorEffect glyph with ID: {}", ANCHOR_EFFECT.getRegistryName());
         
         ArsZero.LOGGER.debug("Registering PushEffect glyph...");
         GlyphRegistry.registerSpell(PUSH_EFFECT);
-        ArsZero.LOGGER.info("Successfully registered PushEffect glyph with ID: {}", PUSH_EFFECT.getRegistryName());
+        ArsZero.LOGGER.debug("Successfully registered PushEffect glyph with ID: {}", PUSH_EFFECT.getRegistryName());
         
         ArsZero.LOGGER.debug("Registering RemoveGravity glyph...");
         GlyphRegistry.registerSpell(ZERO_GRAVITY_EFFECT);
-        ArsZero.LOGGER.info("Successfully registered RemoveGravity glyph with ID: {}", ZERO_GRAVITY_EFFECT.getRegistryName());
+        ArsZero.LOGGER.debug("Successfully registered RemoveGravity glyph with ID: {}", ZERO_GRAVITY_EFFECT.getRegistryName());
         
         ArsZero.LOGGER.debug("Glyph registration completed");
     }

--- a/src/main/java/com/github/ars_zero/registry/ModItems.java
+++ b/src/main/java/com/github/ars_zero/registry/ModItems.java
@@ -87,7 +87,7 @@ public class ModItems {
     public static final DeferredHolder<Item, RendererBlockItem> MULTIPHASE_SPELL_TURRET = ITEMS.register(
         "multiphase_spell_turret",
         () -> {
-            ArsZero.LOGGER.info("Registering Multiphase Spell Turret item");
+            ArsZero.LOGGER.debug("Registering Multiphase Spell Turret item");
             RendererBlockItem item = new RendererBlockItem(ModBlocks.MULTIPHASE_SPELL_TURRET.get(), defaultItemProperties()) {
                 @Override
                 @OnlyIn(Dist.CLIENT)
@@ -95,7 +95,7 @@ public class ModItems {
                     return MultiphaseTurretItemRenderer.getISTER();
                 }
             };
-            ArsZero.LOGGER.info("Multiphase Spell Turret item created successfully");
+            ArsZero.LOGGER.debug("Multiphase Spell Turret item created successfully");
             return item;
         }
     );
@@ -110,13 +110,13 @@ public class ModItems {
     }
 
     public static void registerSpellCasters() {
-        ArsZero.LOGGER.info("Registering Ars Zero staves with SpellCasterRegistry");
+        ArsZero.LOGGER.debug("Registering Ars Zero staves with SpellCasterRegistry");
         registerStaff(NOVICE_SPELL_STAFF.get());
         registerStaff(MAGE_SPELL_STAFF.get());
         registerStaff(ARCHMAGE_SPELL_STAFF.get());
         registerStaff(CREATIVE_SPELL_STAFF.get());
         registerDevice(SPELLCASTING_CIRCLET.get());
-        ArsZero.LOGGER.info("SpellCasterRegistry registration completed");
+        ArsZero.LOGGER.debug("SpellCasterRegistry registration completed");
     }
     
     private static void registerStaff(AbstractSpellStaff staff) {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger level="INFO" name="com.github.ars_zero"/>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger level="INFO" name="com.github.ars_zero"/>
+        <Logger level="INFO" name="ars_zero"/>
         <Root level="INFO">
             <AppenderRef ref="Console"/>
         </Root>

--- a/src/test/java/com/arszero/tests/FriendlyTestReporter.java
+++ b/src/test/java/com/arszero/tests/FriendlyTestReporter.java
@@ -42,7 +42,7 @@ public final class FriendlyTestReporter implements TestReporter {
         int totalCount = passedCount + failedCount;
         List<String> lines = buildSummary(totalCount, passedCount, failedCount);
         FINAL_LINES.set(lines);
-        lines.forEach(line -> LOGGER.info("{}", line));
+        lines.forEach(line -> LOGGER.debug("{}", line));
         summaryPrinted = true;
     }
 

--- a/src/test/java/com/arszero/tests/TestRegistrationFilter.java
+++ b/src/test/java/com/arszero/tests/TestRegistrationFilter.java
@@ -36,7 +36,7 @@ public final class TestRegistrationFilter {
 
     public static void applyFilterToRegistry() {
         if (ALLOWED_CLASSES.isEmpty()) {
-            LOGGER.info("No test filter provided; registry pruning skipped.");
+            LOGGER.debug("No test filter provided; registry pruning skipped.");
             return;
         }
         GameTestHooks.registerGametests();
@@ -51,7 +51,7 @@ public final class TestRegistrationFilter {
         int before = allFunctions.size();
         allFunctions.removeIf(function -> !allowedFunctions.contains(function));
         int removed = before - allFunctions.size();
-        LOGGER.info("Filtered game tests: removed {}, remaining {}.", removed, allFunctions.size());
+        LOGGER.debug("Filtered game tests: removed {}, remaining {}.", removed, allFunctions.size());
         GameTestRegistry.getAllTestClassNames().retainAll(allowedBatchNames);
     }
 
@@ -61,7 +61,7 @@ public final class TestRegistrationFilter {
         }
         boolean enabled = ALLOWED_CLASSES.contains(testClass);
         if (!enabled) {
-            LOGGER.info("Skipping registration for {} due to test filter property.", testClass.getName());
+            LOGGER.debug("Skipping registration for {} due to test filter property.", testClass.getName());
         }
         return enabled;
     }
@@ -78,7 +78,7 @@ public final class TestRegistrationFilter {
     private static Set<Class<?>> resolveAllowedClasses() {
         String raw = resolveRawFilter();
         if (raw.isEmpty()) {
-            LOGGER.info("No test filter provided; running full suite.");
+            LOGGER.debug("No test filter provided; running full suite.");
             return Collections.emptySet();
         }
         String source = determineFilterSource();
@@ -99,7 +99,7 @@ public final class TestRegistrationFilter {
             LOGGER.warn("No valid test filters resolved; running full suite.");
             return Collections.emptySet();
         }
-        LOGGER.info("Applying test filter ({}) for classes: {}", source, parsed.stream().map(Class::getSimpleName).collect(Collectors.joining(", ")));
+        LOGGER.debug("Applying test filter ({}) for classes: {}", source, parsed.stream().map(Class::getSimpleName).collect(Collectors.joining(", ")));
         return Collections.unmodifiableSet(parsed);
     }
 


### PR DESCRIPTION
Convert all `INFO` level logs to `DEBUG` and configure `log4j2` to prevent `DEBUG` logs from appearing in production builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-85c809c1-1e56-4dc5-949c-0f2992b6e900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85c809c1-1e56-4dc5-949c-0f2992b6e900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

