### PR TITLE
Explosion process claimed chunks

### DIFF
--- a/src/main/java/com/github/ars_zero/common/entity/explosion/ExplosionBurstProjectile.java
+++ b/src/main/java/com/github/ars_zero/common/entity/explosion/ExplosionBurstProjectile.java
@@ -1,12 +1,15 @@
 package com.github.ars_zero.common.entity.explosion;
 
+import com.hollingsworth.arsnouveau.api.ANFakePlayer;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.level.ClipContext;
@@ -15,6 +18,9 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
 
 public class ExplosionBurstProjectile extends Projectile {
 
@@ -28,6 +34,8 @@ public class ExplosionBurstProjectile extends Projectile {
   private int age = 0;
   private static final int MAX_AGE = 100; // 5 seconds max lifetime
   private static final double GRAVITY = 0.08; // Stronger gravity than default
+  @Nullable
+  private UUID casterUUID = null;
 
   public ExplosionBurstProjectile(EntityType<? extends Projectile> entityType, Level level) {
     super(entityType, level);
@@ -70,6 +78,23 @@ public class ExplosionBurstProjectile extends Projectile {
   public boolean isSoulfire() {
     // Blue color indicates soulfire (0.3, 0.7, 1.0)
     return this.getB() > 0.9f && this.getR() < 0.5f;
+  }
+
+  public void setCasterUUID(@Nullable UUID casterUUID) {
+    this.casterUUID = casterUUID;
+  }
+
+  @Nullable
+  public UUID getCasterUUID() {
+    return casterUUID;
+  }
+
+  @Nullable
+  private Player getClaimActor(ServerLevel level) {
+    if (casterUUID == null) {
+      return null;
+    }
+    return ANFakePlayer.getPlayer(level, casterUUID);
   }
 
   @Override
@@ -144,8 +169,9 @@ public class ExplosionBurstProjectile extends Projectile {
   protected void onHitBlock(BlockHitResult result) {
     super.onHitBlock(result);
     if (!this.level().isClientSide && this.level() instanceof ServerLevel serverLevel) {
+      Player claimActor = getClaimActor(serverLevel);
       boolean isSoulfire = this.isSoulfire();
-      FireIgnitionHelper.igniteBlock(serverLevel, result.getBlockPos(), isSoulfire);
+      FireIgnitionHelper.igniteBlock(serverLevel, result.getBlockPos(), isSoulfire, claimActor);
     }
   }
 
@@ -164,6 +190,22 @@ public class ExplosionBurstProjectile extends Projectile {
       this.onHitBlock(blockHit);
     } else if (result instanceof EntityHitResult entityHit) {
       this.onHitEntity(entityHit);
+    }
+  }
+
+  @Override
+  protected void readAdditionalSaveData(CompoundTag compound) {
+    super.readAdditionalSaveData(compound);
+    if (compound.contains("casterUUID")) {
+      this.casterUUID = compound.getUUID("casterUUID");
+    }
+  }
+
+  @Override
+  protected void addAdditionalSaveData(CompoundTag compound) {
+    super.addAdditionalSaveData(compound);
+    if (casterUUID != null) {
+      compound.putUUID("casterUUID", casterUUID);
     }
   }
 }

--- a/src/main/java/com/github/ars_zero/common/entity/explosion/ExplosionControllerEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/explosion/ExplosionControllerEntity.java
@@ -7,6 +7,7 @@ import com.github.ars_zero.common.entity.IAnchorLerp;
 import com.github.ars_zero.common.explosion.LargeExplosionDamage;
 import com.github.ars_zero.common.explosion.LargeExplosionPrecompute;
 import com.github.ars_zero.common.explosion.ExplosionWorkList;
+import com.hollingsworth.arsnouveau.api.ANFakePlayer;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
 import com.hollingsworth.arsnouveau.api.spell.SpellStats;
@@ -32,6 +33,8 @@ import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.animation.PlayState;
 import software.bernie.geckolib.animation.RawAnimation;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
 
 public class ExplosionControllerEntity extends AbstractConvergenceEntity implements IAnchorLerp {
     private enum AnimState {
@@ -115,12 +118,32 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
     private SoundEvent resolveSound = null;
     private boolean resolveSoundPlayed = false;
 
+    @Nullable
+    private UUID casterUUID = null;
+
     public ExplosionControllerEntity(EntityType<?> entityType, Level level) {
         super(entityType, level);
         this.charge = 0.0f;
         this.firePower = 0.0;
         this.explodeAnimationStartTick = 0;
         this.explodeAnimationDurationTicks = (int) (BASE_EXPLODE_ANIMATION_SECONDS * 20.0) - 2;
+    }
+
+    public void setCasterUUID(@Nullable UUID casterUUID) {
+        this.casterUUID = casterUUID;
+    }
+
+    @Nullable
+    public UUID getCasterUUID() {
+        return casterUUID;
+    }
+
+    @Nullable
+    Player getClaimActor(ServerLevel level) {
+        if (casterUUID == null) {
+            return null;
+        }
+        return ANFakePlayer.getPlayer(level, casterUUID);
     }
 
     @Override
@@ -461,7 +484,7 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
 
         // Spawn explosion fire projectiles
         ExplosionProcessHelper.spawnExplosionFireProjectiles(serverLevel, center, calculatedRadius, this.firePower,
-                currentCharge);
+                currentCharge, this);
 
         // Shake nearby players
         ExplosionShakeHelper.shakeNearbyPlayers(serverLevel, center, calculatedRadius);
@@ -546,9 +569,10 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
         }
 
         int maxPerTick = Math.max(1, ServerConfig.LARGE_EXPLOSION_MAX_BLOCKS_PER_TICK.get());
+        Player claimActor = getClaimActor(serverLevel);
         ExplosionProcessHelper.ProcessResult result = ExplosionProcessHelper.processWorkList(
                 serverLevel, this, workList, nextWorkIndex, this.explosionCenter, this.explosionRadius,
-                this.deferredPositions, this.deferredSize, maxPerTick, this.firePower, this.amplifyLevel);
+                this.deferredPositions, this.deferredSize, maxPerTick, this.firePower, this.amplifyLevel, claimActor);
 
         if (result.highestRing > 14 && result.highestRing > this.lastProcessedRing) {
             for (int ring = this.lastProcessedRing + 1; ring <= result.highestRing; ring++) {
@@ -621,6 +645,9 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
         } else {
             this.explodeAnimationDurationTicks = (int) (BASE_EXPLODE_ANIMATION_SECONDS * 20.0);
         }
+        if (compound.contains("casterUUID")) {
+            this.casterUUID = compound.getUUID("casterUUID");
+        }
     }
 
     @Override
@@ -637,6 +664,9 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
         compound.putInt("dampen_level", this.dampenLevel);
         compound.putInt("explodeAnimationStartTick", this.explodeAnimationStartTick);
         compound.putInt("explodeAnimationDurationTicks", this.explodeAnimationDurationTicks);
+        if (casterUUID != null) {
+            compound.putUUID("casterUUID", casterUUID);
+        }
     }
 
 }

--- a/src/main/java/com/github/ars_zero/common/entity/explosion/FireIgnitionHelper.java
+++ b/src/main/java/com/github/ars_zero/common/entity/explosion/FireIgnitionHelper.java
@@ -1,10 +1,13 @@
 package com.github.ars_zero.common.entity.explosion;
 
+import com.hollingsworth.arsnouveau.api.util.BlockUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
 public class FireIgnitionHelper {
 
@@ -21,9 +24,12 @@ public class FireIgnitionHelper {
    * @param level      The server level
    * @param hitPos     The position that was hit (usually a solid block)
    * @param isSoulfire Whether to use soulfire (blue) or regular fire (orange)
+   * @param claimActor The player to check claims for, or null to skip claim
+   *                   checks
    * @return true if fire was placed, false otherwise
    */
-  public static boolean igniteBlock(ServerLevel level, BlockPos hitPos, boolean isSoulfire) {
+  public static boolean igniteBlock(ServerLevel level, BlockPos hitPos, boolean isSoulfire,
+      @Nullable Player claimActor) {
     BlockState state = level.getBlockState(hitPos);
 
     // Try to place fire above the hit block
@@ -36,6 +42,13 @@ public class FireIgnitionHelper {
     BlockState firePosState = level.getBlockState(firePos);
     if (!firePosState.isAir()) {
       return false;
+    }
+
+    if (claimActor != null) {
+      if (!BlockUtil.destroyRespectsClaim(claimActor, level, hitPos) ||
+          !BlockUtil.destroyRespectsClaim(claimActor, level, firePos)) {
+        return false;
+      }
     }
 
     // For soulfire, use regular fire if block is too soft (hardness < 0.5)

--- a/src/main/java/com/github/ars_zero/common/glyph/EffectConvergence.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/EffectConvergence.java
@@ -79,6 +79,9 @@ public class EffectConvergence extends AbstractEffect implements ISubsequentEffe
             ExplosionControllerEntity entity = new ExplosionControllerEntity(ModEntities.EXPLOSION_CONTROLLER.get(),
                     serverLevel);
             entity.setPos(pos.x, pos.y, pos.z);
+            if (shooter != null) {
+                entity.setCasterUUID(shooter.getUUID());
+            }
 
             SpellContext iterator = spellContext.clone();
             while (iterator.hasNextPart()) {


### PR DESCRIPTION
Thread the caster UUID to the explosion controller to enable respecting claimed chunks during explosions.

---
<a href="https://cursor.com/background-agent?bcId=bc-cefcd937-60df-4f93-825a-441ac4e96388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cefcd937-60df-4f93-825a-441ac4e96388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

