### PR TITLE
Explosion entity age bug

### DIFF
--- a/src/main/java/com/github/ars_zero/common/entity/AbstractConvergenceEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/AbstractConvergenceEntity.java
@@ -125,8 +125,14 @@ public abstract class AbstractConvergenceEntity extends Entity implements ILifes
 
     @Override
     public void addLifespan(LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        this.lifespan++;
-        this.maxLifespan = Math.max(this.maxLifespan, this.lifespan);
+        int newLifespan = this.lifespan + 1;
+        if (this.maxLifespan > 0) {
+            newLifespan = Math.min(this.maxLifespan, newLifespan);
+        } else {
+            this.maxLifespan = Math.max(0, newLifespan);
+        }
+
+        this.lifespan = newLifespan;
         if (!this.level().isClientSide) {
             this.entityData.set(DATA_LIFESPAN, this.lifespan);
             this.entityData.set(DATA_MAX_LIFESPAN, this.maxLifespan);

--- a/src/main/java/com/github/ars_zero/common/entity/AbstractConvergenceEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/AbstractConvergenceEntity.java
@@ -3,7 +3,6 @@ package com.github.ars_zero.common.entity;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
 import com.hollingsworth.arsnouveau.api.spell.SpellStats;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
@@ -20,9 +19,11 @@ import software.bernie.geckolib.animatable.instance.AnimatableInstanceCache;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
 public abstract class AbstractConvergenceEntity extends Entity implements ILifespanExtendable, GeoEntity {
-    private static final EntityDataAccessor<Integer> DATA_LIFESPAN = SynchedEntityData.defineId(AbstractConvergenceEntity.class, EntityDataSerializers.INT);
-    private static final EntityDataAccessor<Integer> DATA_MAX_LIFESPAN = SynchedEntityData.defineId(AbstractConvergenceEntity.class, EntityDataSerializers.INT);
-    
+    private static final EntityDataAccessor<Integer> DATA_LIFESPAN = SynchedEntityData
+            .defineId(AbstractConvergenceEntity.class, EntityDataSerializers.INT);
+    private static final EntityDataAccessor<Integer> DATA_MAX_LIFESPAN = SynchedEntityData
+            .defineId(AbstractConvergenceEntity.class, EntityDataSerializers.INT);
+
     private int lifespan;
     private int maxLifespan;
 
@@ -63,7 +64,7 @@ public abstract class AbstractConvergenceEntity extends Entity implements ILifes
     @Override
     public void tick() {
         super.tick();
-        
+
         if (!this.level().isClientSide) {
             if (this.lifespan > 0) {
                 this.lifespan--;
@@ -124,12 +125,11 @@ public abstract class AbstractConvergenceEntity extends Entity implements ILifes
     }
 
     @Override
-    public void addLifespan(LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+    public void addLifespan(LivingEntity shooter, SpellStats spellStats, SpellContext spellContext,
+            SpellResolver resolver) {
         int newLifespan = this.lifespan + 1;
         if (this.maxLifespan > 0) {
             newLifespan = Math.min(this.maxLifespan, newLifespan);
-        } else {
-            this.maxLifespan = Math.max(0, newLifespan);
         }
 
         this.lifespan = newLifespan;
@@ -146,4 +146,3 @@ public abstract class AbstractConvergenceEntity extends Entity implements ILifes
         return cache;
     }
 }
-

--- a/src/main/java/com/github/ars_zero/common/entity/explosion/ExplosionControllerEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/explosion/ExplosionControllerEntity.java
@@ -111,10 +111,6 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
     private boolean activateSoundPlayed = false;
 
     @Nullable
-    private SoundEvent warningSound = null;
-    private boolean warningSoundPlayed = false;
-
-    @Nullable
     private SoundEvent resolveSound = null;
     private boolean resolveSoundPlayed = false;
 
@@ -287,7 +283,7 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
 
         float charge = this.getCharge();
         int remainingLifespan = this.getLifespan();
-        boolean shouldPlayIdle = (charge >= 1.0f || (remainingLifespan < 20 && charge < 1.0f));
+        boolean shouldPlayIdle = (charge >= 0.98f || (remainingLifespan < 20 && charge < 0.98f));
         boolean shouldPlayCharge = (charge < 1.0f && remainingLifespan >= 20);
         boolean shouldPlayPriming = (remainingLifespan <= 19);
 
@@ -404,10 +400,6 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
         this.aoeLevel = aoeLevel;
         this.amplifyLevel = amplifyLevel;
         this.dampenLevel = dampenLevel;
-    }
-
-    public void setWarningSound(@Nullable SoundEvent sound) {
-        this.warningSound = sound;
     }
 
     public void setResolveSound(@Nullable SoundEvent sound) {
@@ -537,17 +529,11 @@ public class ExplosionControllerEntity extends AbstractConvergenceEntity impleme
             float charge = this.getCharge();
             int remainingLifespan = this.getLifespan();
 
-            if (remainingLifespan == 19 && !resolveSoundPlayed && resolveSound != null) {
+            if (remainingLifespan == 18 && !resolveSoundPlayed && resolveSound != null) {
+                serverLevel.playSound(null, this.getX(), this.getY(), this.getZ(), resolveSound, SoundSource.NEUTRAL,
+                        1.0f, 1.0f);
                 resolveSoundPlayed = true;
             }
-
-            if (remainingLifespan <= 19 && charge > LOW_CHARGE_THRESHOLD && !warningSoundPlayed
-                    && warningSound != null) {
-                serverLevel.playSound(null, this.getX(), this.getY(), this.getZ(), warningSound, SoundSource.NEUTRAL,
-                        1.0f, 1.0f);
-                warningSoundPlayed = true;
-            }
-
             if (this.tickCount % 2 == 0) {
                 ExplosionParticleHelper.spawnSpiralParticles(serverLevel, this.position(), charge, this.tickCount,
                         this.firePower);

--- a/src/main/java/com/github/ars_zero/common/glyph/EffectConvergence.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/EffectConvergence.java
@@ -98,8 +98,6 @@ public class EffectConvergence extends AbstractEffect implements ISubsequentEffe
                             augmentData.amplifyLevel, augmentData.dampenLevel);
                     entity.setLifespan(DEFAULT_LIFESPAN);
 
-                    SoundEvent warningSound = getWarningSoundFromStyle(spellContext);
-                    entity.setWarningSound(warningSound);
                     SoundEvent resolveSound = getResolveSoundFromStyle(spellContext);
                     entity.setResolveSound(resolveSound);
 
@@ -256,11 +254,6 @@ public class EffectConvergence extends AbstractEffect implements ISubsequentEffe
             }
         }
         return null;
-    }
-
-    @Nullable
-    private SoundEvent getWarningSoundFromStyle(SpellContext spellContext) {
-        return getResolveSoundFromStyle(spellContext);
     }
 
     private void triggerResolveEffects(SpellContext spellContext, Level level, Vec3 position) {

--- a/src/main/resources/assets/ars_zero/animations/explosion_charging.animations.json
+++ b/src/main/resources/assets/ars_zero/animations/explosion_charging.animations.json
@@ -450,6 +450,7 @@
       }
     },
     "explode": {
+      "loop": "hold_on_last_frame",
       "animation_length": 1,
       "bones": {
         "ring_primary": {

--- a/src/main/resources/assets/ars_zero/geo/explosion_charging.geo.json
+++ b/src/main/resources/assets/ars_zero/geo/explosion_charging.geo.json
@@ -1,549 +1,549 @@
 {
-	"format_version": "1.12.0",
-	"minecraft:geometry": [
-		{
-			"description": {
-				"identifier": "geometry.unknown",
-				"texture_width": 256,
-				"texture_height": 256,
-				"visible_bounds_width": 47,
-				"visible_bounds_height": 21,
-				"visible_bounds_offset": [0, 0.5, 0]
-			},
-			"bones": [
-				{
-					"name": "explosion",
-					"pivot": [0, 140, 0]
-				},
-				{
-					"name": "ring_secondary_up",
-					"parent": "explosion",
-					"pivot": [0, 1, 0],
-					"cubes": [
-						{
-							"origin": [-30.2, 16, -31],
-							"size": [61, 1, 61],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [125, 1], "uv_size": [61, 61]}
-							}
-						}
-					]
-				},
-				{
-					"name": "ring_primary_outer2",
-					"parent": "explosion",
-					"pivot": [0, 0, 0],
-					"cubes": [
-						{
-							"origin": [0, 0, 0],
-							"size": [64, 1, 64],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [151, 149], "uv_size": [64, 64]}
-							}
-						},
-						{
-							"origin": [0, -16, 0],
-							"size": [64, 1, 64],
-							"pivot": [0, 0, 0],
-							"rotation": [0, -45, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [210, 22], "uv_size": [3, 1]}
-							}
-						},
-						{
-							"origin": [0, 0, 0],
-							"size": [64, 1, 64],
-							"pivot": [0, 0, 0],
-							"rotation": [0, -90, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [151, 149], "uv_size": [64, 64]}
-							}
-						},
-						{
-							"origin": [0, 16, 0],
-							"size": [64, 1, 64],
-							"pivot": [0, 0, 0],
-							"rotation": [0, -135, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [151, 149], "uv_size": [64, 64]}
-							}
-						},
-						{
-							"origin": [0, 0, 0],
-							"size": [64, 1, 64],
-							"pivot": [0, 0, 0],
-							"rotation": [0, 180, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [151, 149], "uv_size": [64, 64]}
-							}
-						},
-						{
-							"origin": [0, 16, 0],
-							"size": [64, 1, 64],
-							"pivot": [0, 0, 0],
-							"rotation": [0, 135, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [151, 149], "uv_size": [64, 64]}
-							}
-						},
-						{
-							"origin": [0, 0, 0],
-							"size": [64, 1, 64],
-							"pivot": [0, 0, 0],
-							"rotation": [0, 90, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [151, 149], "uv_size": [64, 64]}
-							}
-						},
-						{
-							"origin": [0, -16, 0],
-							"size": [64, 1, 64],
-							"pivot": [0, 0, 0],
-							"rotation": [0, 45, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [151, 149], "uv_size": [64, 64]}
-							}
-						}
-					]
-				},
-				{
-					"name": "ring_primary_outer",
-					"parent": "explosion",
-					"pivot": [0, 0, 0],
-					"cubes": [
-						{
-							"origin": [0, 0, 0],
-							"size": [130, 1, 130],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [124, 124], "uv_size": [130, 130]}
-							}
-						},
-						{
-							"origin": [0, 0, 0],
-							"size": [130, 1, 130],
-							"pivot": [0, 0, 0],
-							"rotation": [0, -90, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [124, 124], "uv_size": [130, 130]}
-							}
-						},
-						{
-							"origin": [0, 0, 0],
-							"size": [130, 1, 130],
-							"pivot": [0, 0, 0],
-							"rotation": [0, 180, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [124, 124], "uv_size": [130, 130]}
-							}
-						},
-						{
-							"origin": [0, 0, 0],
-							"size": [130, 1, 130],
-							"pivot": [0, 0, 0],
-							"rotation": [0, 90, 0],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [124, 124], "uv_size": [130, 130]}
-							}
-						}
-					]
-				},
-				{
-					"name": "ring_primary",
-					"parent": "explosion",
-					"pivot": [0, 0, 0],
-					"cubes": [
-						{
-							"origin": [-62, 0, -63],
-							"size": [124, 1, 124],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [0, 0], "uv_size": [124, 124]}
-							}
-						}
-					]
-				},
-				{
-					"name": "ring_primary_small",
-					"parent": "explosion",
-					"pivot": [0, 0, 0],
-					"cubes": [
-						{
-							"origin": [-15.5, 0, -14.5],
-							"size": [31, 1, 30],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [199, 7], "uv_size": [31, 30]}
-							}
-						}
-					]
-				},
-				{
-					"name": "ring_secondary_down",
-					"parent": "explosion",
-					"pivot": [0, 1, 0],
-					"cubes": [
-						{
-							"origin": [-30.2, -16, -31],
-							"size": [61, 1, 61],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [125, 1], "uv_size": [61, 61]}
-							}
-						}
-					]
-				},
-				{
-					"name": "ring_tertiary_down",
-					"parent": "explosion",
-					"pivot": [0, 4, 0],
-					"cubes": [
-						{
-							"origin": [-15.5, -32, -14.5],
-							"size": [31, 1, 30],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [199, 7], "uv_size": [31, 30]}
-							}
-						}
-					]
-				},
-				{
-					"name": "ring_tertiary_up",
-					"parent": "explosion",
-					"pivot": [0, 4, 0],
-					"cubes": [
-						{
-							"origin": [-15.5, 32, -14.5],
-							"size": [31, 1, 30],
-							"uv": {
-								"north": {"uv": [0, 0], "uv_size": [0, 0]},
-								"east": {"uv": [0, 0], "uv_size": [0, 0]},
-								"south": {"uv": [0, 0], "uv_size": [0, 0]},
-								"west": {"uv": [0, 0], "uv_size": [-1, -44]},
-								"up": {"uv": [256, 256], "uv_size": [0, 0]},
-								"down": {"uv": [199, 7], "uv_size": [31, 30]}
-							}
-						}
-					]
-				},
-				{
-					"name": "core_charging",
-					"parent": "explosion",
-					"pivot": [0, 0, 0],
-					"rotation": [0, 0, 90],
-					"cubes": [
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [0, -45, 0],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-45, -45, 0],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-45, -45, 45],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-90, -45, 45],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-90, -45, 90],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [45, -45, 90],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [45, -45, -45],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						}
-					]
-				},
-				{
-					"name": "core_exploding",
-					"parent": "explosion",
-					"pivot": [0, 0, 0],
-					"rotation": [0, 0, 90],
-					"cubes": [
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [0, -45, 0],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-45, -45, 0],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-45, -45, 45],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-90, -45, 45],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [-90, -45, 90],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [45, -45, 90],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						},
-						{
-							"origin": [-4, -4, -4],
-							"size": [8, 8, 8],
-							"pivot": [0, 0, 0],
-							"rotation": [45, -45, -45],
-							"uv": {
-								"north": {"uv": [2, 256], "uv_size": [2, -2]},
-								"east": {"uv": [2, 256], "uv_size": [2, -2]},
-								"south": {"uv": [2, 254], "uv_size": [2, 2]},
-								"west": {"uv": [2, 256], "uv_size": [2, -2]},
-								"up": {"uv": [2, 254], "uv_size": [2, 2]},
-								"down": {"uv": [4, 254], "uv_size": [-2, 2]}
-							}
-						}
-					]
-				}
-			]
-		}
-	]
+  "format_version": "1.12.0",
+  "minecraft:geometry": [
+    {
+      "description": {
+        "identifier": "geometry.unknown",
+        "texture_width": 256,
+        "texture_height": 256,
+        "visible_bounds_width": 47,
+        "visible_bounds_height": 21,
+        "visible_bounds_offset": [0, 0.5, 0]
+      },
+      "bones": [
+        {
+          "name": "explosion",
+          "pivot": [0, 140, 0]
+        },
+        {
+          "name": "ring_secondary_up",
+          "parent": "explosion",
+          "pivot": [0, 1, 0],
+          "cubes": [
+            {
+              "origin": [-30.2, 16, -31],
+              "size": [61, 1, 61],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [125, 1], "uv_size": [61, 61] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "ring_primary_outer2",
+          "parent": "explosion",
+          "pivot": [0, 0, 0],
+          "cubes": [
+            {
+              "origin": [0, 0, 0],
+              "size": [64, 1, 64],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            },
+            {
+              "origin": [0, -16, 0],
+              "size": [64, 1, 64],
+              "pivot": [0, 0, 0],
+              "rotation": [0, -45, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            },
+            {
+              "origin": [0, 0, 0],
+              "size": [64, 1, 64],
+              "pivot": [0, 0, 0],
+              "rotation": [0, -90, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            },
+            {
+              "origin": [0, 16, 0],
+              "size": [64, 1, 64],
+              "pivot": [0, 0, 0],
+              "rotation": [0, -135, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            },
+            {
+              "origin": [0, 0, 0],
+              "size": [64, 1, 64],
+              "pivot": [0, 0, 0],
+              "rotation": [0, 180, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            },
+            {
+              "origin": [0, 16, 0],
+              "size": [64, 1, 64],
+              "pivot": [0, 0, 0],
+              "rotation": [0, 135, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            },
+            {
+              "origin": [0, 0, 0],
+              "size": [64, 1, 64],
+              "pivot": [0, 0, 0],
+              "rotation": [0, 90, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            },
+            {
+              "origin": [0, -16, 0],
+              "size": [64, 1, 64],
+              "pivot": [0, 0, 0],
+              "rotation": [0, 45, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [151, 149], "uv_size": [64, 64] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "ring_primary_outer",
+          "parent": "explosion",
+          "pivot": [0, 0, 0],
+          "cubes": [
+            {
+              "origin": [0, 0, 0],
+              "size": [130, 1, 130],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [124, 124], "uv_size": [130, 130] }
+              }
+            },
+            {
+              "origin": [0, 0, 0],
+              "size": [130, 1, 130],
+              "pivot": [0, 0, 0],
+              "rotation": [0, -90, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [124, 124], "uv_size": [130, 130] }
+              }
+            },
+            {
+              "origin": [0, 0, 0],
+              "size": [130, 1, 130],
+              "pivot": [0, 0, 0],
+              "rotation": [0, 180, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [124, 124], "uv_size": [130, 130] }
+              }
+            },
+            {
+              "origin": [0, 0, 0],
+              "size": [130, 1, 130],
+              "pivot": [0, 0, 0],
+              "rotation": [0, 90, 0],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [124, 124], "uv_size": [130, 130] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "ring_primary",
+          "parent": "explosion",
+          "pivot": [0, 0, 0],
+          "cubes": [
+            {
+              "origin": [-62, 0, -63],
+              "size": [124, 1, 124],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [0, 0], "uv_size": [124, 124] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "ring_primary_small",
+          "parent": "explosion",
+          "pivot": [0, 0, 0],
+          "cubes": [
+            {
+              "origin": [-15.5, 0, -14.5],
+              "size": [31, 1, 30],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [199, 7], "uv_size": [31, 30] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "ring_secondary_down",
+          "parent": "explosion",
+          "pivot": [0, 1, 0],
+          "cubes": [
+            {
+              "origin": [-30.2, -16, -31],
+              "size": [61, 1, 61],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [125, 1], "uv_size": [61, 61] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "ring_tertiary_down",
+          "parent": "explosion",
+          "pivot": [0, 4, 0],
+          "cubes": [
+            {
+              "origin": [-15.5, -32, -14.5],
+              "size": [31, 1, 30],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [199, 7], "uv_size": [31, 30] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "ring_tertiary_up",
+          "parent": "explosion",
+          "pivot": [0, 4, 0],
+          "cubes": [
+            {
+              "origin": [-15.5, 32, -14.5],
+              "size": [31, 1, 30],
+              "uv": {
+                "north": { "uv": [0, 0], "uv_size": [0, 0] },
+                "east": { "uv": [0, 0], "uv_size": [0, 0] },
+                "south": { "uv": [0, 0], "uv_size": [0, 0] },
+                "west": { "uv": [0, 0], "uv_size": [-1, -44] },
+                "up": { "uv": [256, 256], "uv_size": [0, 0] },
+                "down": { "uv": [199, 7], "uv_size": [31, 30] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "core_charging",
+          "parent": "explosion",
+          "pivot": [0, 0, 0],
+          "rotation": [0, 0, 90],
+          "cubes": [
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [0, -45, 0],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-45, -45, 0],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-45, -45, 45],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-90, -45, 45],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-90, -45, 90],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [45, -45, 90],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [45, -45, -45],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            }
+          ]
+        },
+        {
+          "name": "core_exploding",
+          "parent": "explosion",
+          "pivot": [0, 0, 0],
+          "rotation": [0, 0, 90],
+          "cubes": [
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [0, -45, 0],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-45, -45, 0],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-45, -45, 45],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-90, -45, 45],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [-90, -45, 90],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [45, -45, 90],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            },
+            {
+              "origin": [-4, -4, -4],
+              "size": [8, 8, 8],
+              "pivot": [0, 0, 0],
+              "rotation": [45, -45, -45],
+              "uv": {
+                "north": { "uv": [2, 256], "uv_size": [2, -2] },
+                "east": { "uv": [2, 256], "uv_size": [2, -2] },
+                "south": { "uv": [2, 254], "uv_size": [2, 2] },
+                "west": { "uv": [2, 256], "uv_size": [2, -2] },
+                "up": { "uv": [2, 254], "uv_size": [2, 2] },
+                "down": { "uv": [4, 254], "uv_size": [-2, 2] }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Cap lifespan extension for `AbstractConvergenceEntity` to prevent entities from exceeding their intended max age when anchored.

Previously, `AbstractConvergenceEntity.addLifespan()` would increase both the current `lifespan` and `maxLifespan`. This meant that entities like `ExplosionControllerEntity`, which have a default `maxLifespan` of 20 ticks, could have their `maxLifespan` continually extended by effects like Anchor, causing them to remain in an idle state far beyond the expected 20 ticks.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7a70cfc-4f15-43c2-950d-914a1281ffb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7a70cfc-4f15-43c2-950d-914a1281ffb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

