### PR TITLE
Multi-phase glyph reordering

### DIFF
--- a/src/main/java/com/github/ars_zero/client/gui/SpellPhaseSlots.java
+++ b/src/main/java/com/github/ars_zero/client/gui/SpellPhaseSlots.java
@@ -4,6 +4,7 @@ import com.github.ars_zero.common.spell.SpellPhase;
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 public class SpellPhaseSlots {
     public final List<AbstractSpellPart> begin;
@@ -28,5 +29,75 @@ public class SpellPhaseSlots {
             case TICK -> tick;
             case END -> end;
         };
+    }
+
+    public int getContiguousGlyphCount(SpellPhase phase) {
+        List<AbstractSpellPart> list = getPhaseList(phase);
+        int count = 0;
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i) == null) {
+                break;
+            }
+            count++;
+        }
+        return count;
+    }
+
+    public boolean canInsertGlyph(SpellPhase phase) {
+        return getContiguousGlyphCount(phase) < getPhaseList(phase).size();
+    }
+
+    public boolean trySetGlyph(SpellPhase phase, int slot, @Nullable AbstractSpellPart part) {
+        List<AbstractSpellPart> list = getPhaseList(phase);
+        if (slot < 0 || slot >= list.size()) {
+            return false;
+        }
+        int count = getContiguousGlyphCount(phase);
+        if (part != null && slot > count) {
+            return false;
+        }
+        list.set(slot, part);
+        if (part == null) {
+            for (int i = slot; i < list.size(); i++) {
+                if (list.get(i) != null) {
+                    break;
+                }
+                if (i > slot) {
+                    list.set(i, null);
+                }
+            }
+        }
+        return true;
+    }
+
+    public boolean tryInsertGlyph(SpellPhase phase, int slot, AbstractSpellPart part) {
+        List<AbstractSpellPart> list = getPhaseList(phase);
+        int count = getContiguousGlyphCount(phase);
+        if (count >= list.size()) {
+            return false;
+        }
+        if (slot < 0 || slot > count) {
+            return false;
+        }
+        for (int i = count; i > slot; i--) {
+            list.set(i, list.get(i - 1));
+        }
+        list.set(slot, part);
+        return true;
+    }
+
+    @Nullable
+    public AbstractSpellPart removeGlyphAndShiftLeft(SpellPhase phase, int slot) {
+        List<AbstractSpellPart> list = getPhaseList(phase);
+        int count = getContiguousGlyphCount(phase);
+        if (slot < 0 || slot >= count) {
+            return null;
+        }
+        AbstractSpellPart removed = list.get(slot);
+        for (int i = slot; i < count - 1; i++) {
+            list.set(i, list.get(i + 1));
+        }
+        list.set(count - 1, null);
+        return removed;
     }
 }


### PR DESCRIPTION
Add glyph lifting, replacing, and inserting functionality to the multi-phase screen for intuitive spell component rearrangement.

This PR introduces the ability to right-click a glyph to 'lift' it, then left-click to either replace an existing glyph or insert it between two glyphs (with a 10-glyph limit per phase). Lifting from a phase row automatically removes the glyph and shifts others left. Core list manipulation logic (insert, remove, set) is handled by `SpellPhaseSlots` to ensure contiguous glyph lists and prevent 'null in the middle' issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-db4dc44d-9800-4be1-9503-b245beabfc36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db4dc44d-9800-4be1-9503-b245beabfc36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

