### PR TITLE
Turret convergence mechanics

### DIFF
--- a/src/main/java/com/github/ars_zero/common/entity/SourceJarChargerEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/SourceJarChargerEntity.java
@@ -2,27 +2,26 @@ package com.github.ars_zero.common.entity;
 
 import com.hollingsworth.arsnouveau.client.particle.GlowParticleData;
 import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
-import com.hollingsworth.arsnouveau.api.mana.IManaCap;
+import com.hollingsworth.arsnouveau.api.util.SourceUtil;
 import com.hollingsworth.arsnouveau.common.block.tile.SourceJarTile;
-import com.hollingsworth.arsnouveau.setup.registry.CapabilityRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.UUID;
 
 public class SourceJarChargerEntity extends AbstractChargerEntity {
   private static final String TAG_JAR_POS = "jar_pos";
-  private static final String TAG_INITIAL_SOURCE_ADDED = "initial_source_added";
+  private static final String TAG_SOURCE_ORIGIN_POS = "source_origin_pos";
+  private static final String TAG_INITIAL_BURST_DONE = "initial_burst_done";
 
   private static final int INITIAL_SOURCE_AMOUNT = 200;
+  private static final int SOURCE_PER_TICK = 5;
+  private static final int SOURCE_DRAIN_RANGE = 10;
 
   private BlockPos jarPos;
-  private boolean initialSourceAdded = false;
+  private BlockPos sourceOriginPos;
+  private boolean initialBurstDone = false;
 
   public SourceJarChargerEntity(net.minecraft.world.entity.EntityType<? extends SourceJarChargerEntity> entityType,
       Level level) {
@@ -35,24 +34,60 @@ public class SourceJarChargerEntity extends AbstractChargerEntity {
 
   @Override
   public void tick() {
-    if (!this.level().isClientSide && jarPos != null) {
-      ServerLevel serverLevel = (ServerLevel) this.level();
+    super.tick();
+  }
 
-      if (!initialSourceAdded) {
-        if (serverLevel.getBlockEntity(jarPos) instanceof SourceJarTile jar) {
-          int currentSource = jar.getSource();
-          int maxSource = jar.getMaxSource();
-          int toAdd = Math.min(INITIAL_SOURCE_AMOUNT, maxSource - currentSource);
-          if (toAdd > 0) {
-            jar.setSource(currentSource + toAdd);
-            jar.updateBlock();
-          }
-          initialSourceAdded = true;
-        }
-      }
+  public void setSourceOriginPos(BlockPos pos) {
+    this.sourceOriginPos = pos;
+  }
+
+  @Override
+  protected void onChargeTick(ServerLevel serverLevel) {
+    if (jarPos == null) {
+      return;
+    }
+    if (!(serverLevel.getBlockEntity(jarPos) instanceof SourceJarTile jar)) {
+      return;
+    }
+    if (!jar.canAcceptSource()) {
+      return;
     }
 
-    super.tick();
+    int currentSource = jar.getSource();
+    int maxSource = jar.getMaxSource();
+    int capacity = maxSource - currentSource;
+    if (capacity <= 0) {
+      return;
+    }
+
+    BlockPos drainPos = sourceOriginPos != null ? sourceOriginPos : this.blockPosition();
+    int requested = initialBurstDone ? Math.min(SOURCE_PER_TICK, capacity) : Math.min(INITIAL_SOURCE_AMOUNT, capacity);
+    int drained = drainSource(serverLevel, drainPos, requested);
+    if (drained <= 0) {
+      return;
+    }
+
+    int toAdd = Math.min(drained, maxSource - currentSource);
+    if (toAdd <= 0) {
+      return;
+    }
+
+    jar.setSource(currentSource + toAdd);
+    jar.updateBlock();
+
+    initialBurstDone = true;
+    spawnChargeParticles(serverLevel, getParticlePosition(), tickCount, 10.0);
+  }
+
+  private static int drainSource(ServerLevel serverLevel, BlockPos originPos, int requested) {
+    int amount = requested;
+    while (amount > 0) {
+      if (SourceUtil.takeSourceMultipleWithParticles(originPos, serverLevel, SOURCE_DRAIN_RANGE, amount) != null) {
+        return amount;
+      }
+      amount /= 2;
+    }
+    return 0;
   }
 
   @Override
@@ -143,8 +178,13 @@ public class SourceJarChargerEntity extends AbstractChargerEntity {
     if (compound.contains(TAG_JAR_POS)) {
       this.jarPos = BlockPos.of(compound.getLong(TAG_JAR_POS));
     }
-    if (compound.contains(TAG_INITIAL_SOURCE_ADDED)) {
-      this.initialSourceAdded = compound.getBoolean(TAG_INITIAL_SOURCE_ADDED);
+    if (compound.contains(TAG_SOURCE_ORIGIN_POS)) {
+      this.sourceOriginPos = BlockPos.of(compound.getLong(TAG_SOURCE_ORIGIN_POS));
+    }
+    if (compound.contains(TAG_INITIAL_BURST_DONE)) {
+      this.initialBurstDone = compound.getBoolean(TAG_INITIAL_BURST_DONE);
+    } else if (compound.contains("initial_source_added")) {
+      this.initialBurstDone = compound.getBoolean("initial_source_added");
     }
   }
 
@@ -154,6 +194,9 @@ public class SourceJarChargerEntity extends AbstractChargerEntity {
     if (jarPos != null) {
       compound.putLong(TAG_JAR_POS, jarPos.asLong());
     }
-    compound.putBoolean(TAG_INITIAL_SOURCE_ADDED, initialSourceAdded);
+    if (sourceOriginPos != null) {
+      compound.putLong(TAG_SOURCE_ORIGIN_POS, sourceOriginPos.asLong());
+    }
+    compound.putBoolean(TAG_INITIAL_BURST_DONE, initialBurstDone);
   }
 }

--- a/src/main/java/com/github/ars_zero/common/glyph/convergence/ChargerHelper.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/convergence/ChargerHelper.java
@@ -47,6 +47,7 @@ public final class ChargerHelper {
             chargerEntity.setPos(pos.x, pos.y, pos.z);
             chargerEntity.setJarPos(blockPos);
             chargerEntity.setCasterUUID(shooter.getUUID());
+            chargerEntity.setSourceOriginPos(shooter.blockPosition());
             chargerEntity.setLifespan(DEFAULT_LIFESPAN);
             SoundEvent resolveSound = convergence.getResolveSoundFromStyle(spellContext);
             chargerEntity.setResolveSound(resolveSound);

--- a/src/main/java/com/github/ars_zero/common/glyph/convergence/EffectConvergence.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/convergence/EffectConvergence.java
@@ -19,8 +19,10 @@ import com.hollingsworth.arsnouveau.api.spell.SpellStats;
 import com.hollingsworth.arsnouveau.api.spell.SpellTier;
 import com.hollingsworth.arsnouveau.api.spell.SpellSchools;
 import com.hollingsworth.arsnouveau.api.spell.SpellSchool;
+import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.TileCaster;
 import com.hollingsworth.arsnouveau.common.spell.effect.EffectConjureWater;
 import com.hollingsworth.arsnouveau.common.spell.effect.EffectExplosion;
+import com.github.ars_zero.common.block.MultiphaseSpellTurretTile;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -84,8 +86,14 @@ public class EffectConvergence extends AbstractEffect implements ISubsequentEffe
       return;
     }
 
-    ItemStack casterTool = spellContext.getCasterTool();
-    MultiPhaseCastContext context = AbstractMultiPhaseCastDevice.findContextByStack(player, casterTool);
+    MultiPhaseCastContext context = null;
+    if (spellContext.getCaster() instanceof TileCaster tileCaster && tileCaster.getTile() instanceof MultiphaseSpellTurretTile turretTile) {
+      context = turretTile.getCastContext();
+    }
+    if (context == null) {
+      ItemStack casterTool = spellContext.getCasterTool();
+      context = AbstractMultiPhaseCastDevice.findContextByStack(player, casterTool);
+    }
     if (context == null) {
       return;
     }

--- a/src/main/java/com/github/ars_zero/event/ArsZeroResolverEvents.java
+++ b/src/main/java/com/github/ars_zero/event/ArsZeroResolverEvents.java
@@ -33,6 +33,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -252,6 +253,13 @@ public class ArsZeroResolverEvents {
         
         switch (wrapped.getPhase()) {
             case BEGIN -> {
+                if (result != null && result.hitResult instanceof BlockHitResult && !context.beginResults.isEmpty()) {
+                    for (SpellResult existing : context.beginResults) {
+                        if (existing != null && existing.hitResult instanceof EntityHitResult) {
+                            return;
+                        }
+                    }
+                }
                 if (result != null && result.blockGroup != null) {
                     context.beginResults.clear();
                     context.beginResults.add(result);


### PR DESCRIPTION
Bill convergence jar charging from world source near the turret and enable phase turret sustain to fix mana drain and source exploit.

The previous implementation for convergence jar charging, when cast by a turret, incorrectly drained the original player's mana for continuous operation after an initial source cost. This led to an exploit where player mana regeneration could be converted into a net positive source. Additionally, phase turrets were unable to sustain this effect due to issues in how temporal context was handled for entities versus blocks. This PR re-routes the continuous cost to world source near the turret and ensures proper sustain for turret-spawned charger entities, aligning with the intent for turrets to move source over long distances.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0341cd9-294e-4c12-b210-b840b1374c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0341cd9-294e-4c12-b210-b840b1374c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

