### PR TITLE
Beam timeline color

### DIFF
--- a/src/main/java/com/github/ars_zero/common/glyph/EffectBeam.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/EffectBeam.java
@@ -7,6 +7,7 @@ import com.github.ars_zero.common.spell.MultiPhaseCastContext;
 import com.github.ars_zero.common.spell.SpellEffectType;
 import com.github.ars_zero.common.spell.SpellResult;
 import com.github.ars_zero.common.util.MathHelper;
+import com.hollingsworth.arsnouveau.api.registry.ParticleTimelineRegistry;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
@@ -15,6 +16,7 @@ import com.hollingsworth.arsnouveau.api.spell.SpellStats;
 import com.hollingsworth.arsnouveau.api.spell.SpellTier;
 import com.hollingsworth.arsnouveau.api.spell.SpellSchool;
 import com.hollingsworth.arsnouveau.api.spell.SpellSchools;
+import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
@@ -100,10 +102,23 @@ public class EffectBeam extends AbstractEffect {
             lifetime = EffectBeamEntity.DEFAULT_LIFETIME_TICKS;
         }
 
+        float beamColorR = 1.0f;
+        float beamColorG = 1.0f;
+        float beamColorB = 1.0f;
+        var timeline = spellContext.getParticleTimeline(ParticleTimelineRegistry.PROJECTILE_TIMELINE.get());
+        if (timeline != null) {
+            ParticleColor color = timeline.getColor();
+            if (color != null) {
+                beamColorR = color.getRed();
+                beamColorG = color.getGreen();
+                beamColorB = color.getBlue();
+            }
+        }
+
         boolean dampened = spellStats.getBuffCount(AugmentDampen.INSTANCE) > 0;
         int splitLevel = spellStats.getBuffCount(AugmentSplit.INSTANCE);
         if (splitLevel <= 0) {
-            EffectBeamEntity beam = new EffectBeamEntity(serverLevel, pos.x, pos.y, pos.z, yaw, pitch, lifetime, 1.0f, 1.0f, 1.0f, shooter.getUUID(), dampened);
+            EffectBeamEntity beam = new EffectBeamEntity(serverLevel, pos.x, pos.y, pos.z, yaw, pitch, lifetime, beamColorR, beamColorG, beamColorB, shooter.getUUID(), dampened);
             spellContext.setCanceled(true);
             SpellContext childContext = spellContext.makeChildContext();
             beam.setResolver(resolver.getNewResolver(childContext));
@@ -145,7 +160,7 @@ public class EffectBeam extends AbstractEffect {
         List<Vec3> positions = MathHelper.getCirclePositions(center, circleNormal, circleRadius, entityCount);
         List<EffectBeamEntity> beams = new ArrayList<>();
         for (Vec3 p : positions) {
-            EffectBeamEntity beam = new EffectBeamEntity(serverLevel, p.x, p.y, p.z, yaw, pitch, lifetime, 1.0f, 1.0f, 1.0f, shooter.getUUID(), dampened);
+            EffectBeamEntity beam = new EffectBeamEntity(serverLevel, p.x, p.y, p.z, yaw, pitch, lifetime, beamColorR, beamColorG, beamColorB, shooter.getUUID(), dampened);
             beam.setResolver(childResolver);
             serverLevel.addFreshEntity(beam);
             beams.add(beam);

--- a/src/main/java/com/github/ars_zero/common/glyph/EffectBeam.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/EffectBeam.java
@@ -7,7 +7,7 @@ import com.github.ars_zero.common.spell.MultiPhaseCastContext;
 import com.github.ars_zero.common.spell.SpellEffectType;
 import com.github.ars_zero.common.spell.SpellResult;
 import com.github.ars_zero.common.util.MathHelper;
-import com.hollingsworth.arsnouveau.api.registry.ParticleTimelineRegistry;
+import com.github.ars_zero.registry.ModParticleTimelines;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
@@ -105,7 +105,7 @@ public class EffectBeam extends AbstractEffect {
         float beamColorR = 1.0f;
         float beamColorG = 1.0f;
         float beamColorB = 1.0f;
-        var timeline = spellContext.getParticleTimeline(ParticleTimelineRegistry.PROJECTILE_TIMELINE.get());
+        var timeline = spellContext.getParticleTimeline(ModParticleTimelines.BEAM_TIMELINE.get());
         if (timeline != null) {
             ParticleColor color = timeline.getColor();
             if (color != null) {

--- a/src/main/java/com/github/ars_zero/common/particle/timeline/BeamTimeline.java
+++ b/src/main/java/com/github/ars_zero/common/particle/timeline/BeamTimeline.java
@@ -1,0 +1,52 @@
+package com.github.ars_zero.common.particle.timeline;
+
+import com.github.ars_zero.registry.ModParticleTimelines;
+import com.hollingsworth.arsnouveau.api.particle.configurations.properties.BaseProperty;
+import com.hollingsworth.arsnouveau.api.particle.configurations.properties.ColorProperty;
+import com.hollingsworth.arsnouveau.api.particle.configurations.properties.PropMap;
+import com.hollingsworth.arsnouveau.api.particle.timelines.BaseTimeline;
+import com.hollingsworth.arsnouveau.api.particle.timelines.IParticleTimelineType;
+import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+
+import java.util.List;
+
+public class BeamTimeline extends BaseTimeline<BeamTimeline> {
+    public static final MapCodec<BeamTimeline> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        PropMap.CODEC.fieldOf("propMap").forGetter(i -> i.propMap)
+    ).apply(instance, BeamTimeline::new));
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, BeamTimeline> STREAM_CODEC = StreamCodec.composite(
+        PropMap.STREAM_CODEC,
+        i -> i.propMap,
+        BeamTimeline::new
+    );
+
+    public PropMap propMap;
+
+    public BeamTimeline() {
+        this(new PropMap());
+    }
+
+    public BeamTimeline(PropMap propMap) {
+        this.propMap = propMap == null ? new PropMap() : propMap;
+        this.propMap.createIfMissing(new ColorProperty(ParticleColor.WHITE, false));
+    }
+
+    public ParticleColor getColor() {
+        return propMap.getParticleColor();
+    }
+
+    @Override
+    public IParticleTimelineType<BeamTimeline> getType() {
+        return ModParticleTimelines.BEAM_TIMELINE.get();
+    }
+
+    @Override
+    public List<BaseProperty<?>> getProperties() {
+        return List.of(propMap.createIfMissing(new ColorProperty(ParticleColor.WHITE, false)));
+    }
+}

--- a/src/main/java/com/github/ars_zero/registry/ModParticleTimelines.java
+++ b/src/main/java/com/github/ars_zero/registry/ModParticleTimelines.java
@@ -1,6 +1,7 @@
 package com.github.ars_zero.registry;
 
 import com.github.ars_zero.ArsZero;
+import com.github.ars_zero.common.particle.timeline.BeamTimeline;
 import com.github.ars_zero.common.particle.timeline.ConvergenceTimeline;
 import com.github.ars_zero.common.particle.timeline.DiscardTimeline;
 import com.github.ars_zero.common.particle.timeline.GeometrizeTimeline;
@@ -48,6 +49,12 @@ public class ModParticleTimelines {
                     "geometrize",
                     () -> new SimpleParticleTimelineType<>(ModGlyphs.EFFECT_GEOMETRIZE, GeometrizeTimeline.CODEC,
                             GeometrizeTimeline.STREAM_CODEC, GeometrizeTimeline::new));
+
+    public static final DeferredHolder<IParticleTimelineType<?>, IParticleTimelineType<BeamTimeline>> BEAM_TIMELINE = TIMELINES
+            .register(
+                    "beam",
+                    () -> new SimpleParticleTimelineType<>(ModGlyphs.EFFECT_BEAM, BeamTimeline.CODEC,
+                            BeamTimeline.STREAM_CODEC, BeamTimeline::new));
 
     public static void init(IEventBus eventBus) {
         TIMELINES.register(eventBus);


### PR DESCRIPTION
Add timeline color support to the Beam glyph, allowing custom colors for beams.

---
<a href="https://cursor.com/background-agent?bcId=bc-df6f86c1-3a41-4e18-8b87-e92f12dc2c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df6f86c1-3a41-4e18-8b87-e92f12dc2c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

