### PR TITLE
Beam immunity bypass

### DIFF
--- a/src/main/java/com/github/ars_zero/common/entity/EffectBeamEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/EffectBeamEntity.java
@@ -271,11 +271,19 @@ public class EffectBeamEntity extends Entity implements ILifespanExtendable, IMa
                                 damageSource = this.level().damageSources().indirectMagic(this, livingCaster);
                             }
                         }
-                        target.hurt(damageSource, damage);
+                        applyBeamDamage(target, damageSource, damage);
                     }
                 }
             }
         }
+    }
+
+    private void applyBeamDamage(LivingEntity target, DamageSource damageSource, float damage) {
+        // Bypass vanilla damage cooldown for beam ticks.
+        int previousInvulnerableTime = target.invulnerableTime;
+        target.invulnerableTime = 0;
+        target.hurt(damageSource, damage);
+        target.invulnerableTime = previousInvulnerableTime;
     }
 
     @Override


### PR DESCRIPTION
Bypass living entity damage immunity cooldown for beam damage.

This change allows beams to deal damage every tick by temporarily clearing the target's `invulnerableTime` before applying damage, then restoring it.

---
<a href="https://cursor.com/background-agent?bcId=bc-3da0c9c9-f49e-4421-bfdf-7e4c9de4d6dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3da0c9c9-f49e-4421-bfdf-7e4c9de4d6dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

