### PR TITLE
Block group entities usage rules

### DIFF
--- a/src/main/java/com/github/ars_zero/common/config/ServerConfig.java
+++ b/src/main/java/com/github/ars_zero/common/config/ServerConfig.java
@@ -7,7 +7,6 @@ public class ServerConfig {
     public static ModConfigSpec SERVER_CONFIG;
     public static ModConfigSpec.BooleanValue ALLOW_NON_OP_ANCHOR_ON_PLAYERS;
     public static ModConfigSpec.IntValue LARGE_EXPLOSION_MAX_BLOCKS_PER_TICK;
-    public static ModConfigSpec.BooleanValue ALLOW_BLOCK_GROUP_CREATION;
 
     static {
         ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
@@ -23,15 +22,6 @@ public class ServerConfig {
         LARGE_EXPLOSION_MAX_BLOCKS_PER_TICK = SERVER_BUILDER.comment(
                 "Hard per-tick block destruction budget for large explosions.")
                 .defineInRange("maxBlocksPerTick", 256, 1, 1000000);
-        SERVER_BUILDER.pop();
-
-        SERVER_BUILDER.comment("Select/Anchor Block Group Settings").push("select_anchor");
-        ALLOW_BLOCK_GROUP_CREATION = SERVER_BUILDER.comment(
-                "EXPERIMENTAL: Allow Select and Anchor effects to create block group entities.",
-                "When set to false (default), block group entities cannot be created.",
-                "When set to true, Select and Anchor can create block group entities for block translation.",
-                "This feature is experimental and may cause performance issues or unexpected behavior.")
-                .define("allowBlockGroupCreation", false);
         SERVER_BUILDER.pop();
 
         SERVER_CONFIG = SERVER_BUILDER.build();

--- a/src/main/java/com/github/ars_zero/common/entity/BlockGroupEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/BlockGroupEntity.java
@@ -111,7 +111,7 @@ public class BlockGroupEntity extends Entity implements ILifespanExtendable {
             }
             
             BlockState state = level().getBlockState(pos);
-            if (state.isAir()) {
+            if (!BlockImmutabilityUtil.canBlockBeGrouped(level(), pos, state)) {
                 continue;
             }
             
@@ -134,7 +134,7 @@ public class BlockGroupEntity extends Entity implements ILifespanExtendable {
     public void addBlocksWithStates(List<BlockPos> positions, Map<BlockPos, BlockState> capturedStates) {
         for (BlockPos pos : positions) {
             BlockState state = capturedStates.get(pos);
-            if (state == null || state.isAir()) {
+            if (state == null || !BlockImmutabilityUtil.canBlockBeGrouped(level(), pos, state)) {
                 continue;
             }
             
@@ -158,7 +158,7 @@ public class BlockGroupEntity extends Entity implements ILifespanExtendable {
         if (level().isOutsideBuildHeight(pos)) return;
         
         BlockState state = level().getBlockState(pos);
-        if (state.isAir()) return;
+        if (!BlockImmutabilityUtil.canBlockBeGrouped(level(), pos, state)) return;
         
         BlockEntity tileEntity = level().getBlockEntity(pos);
         if (tileEntity != null) {

--- a/src/main/java/com/github/ars_zero/common/glyph/SelectEffect.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/SelectEffect.java
@@ -1,7 +1,6 @@
 package com.github.ars_zero.common.glyph;
 
 import com.github.ars_zero.ArsZero;
-import com.github.ars_zero.common.config.ServerConfig;
 import com.github.ars_zero.common.entity.BlockGroupEntity;
 import com.github.ars_zero.common.spell.IMultiPhaseCaster;
 import com.github.ars_zero.common.spell.SpellResult;
@@ -68,7 +67,7 @@ public class SelectEffect extends AbstractEffect {
             return;
         }
         
-        if (!BlockImmutabilityUtil.canBlockBeDestroyed(world, pos)) {
+        if (!BlockImmutabilityUtil.canBlockBeGrouped(world, pos)) {
             return;
         }
         double aoeBuff = spellStats.getAoeMultiplier();
@@ -77,9 +76,9 @@ public class SelectEffect extends AbstractEffect {
         
         List<BlockPos> validBlocks = new ArrayList<>();
         for (BlockPos blockPos : posList) {
-            if (!world.isOutsideBuildHeight(blockPos) 
+            if (!world.isOutsideBuildHeight(blockPos)
                 && BlockUtil.destroyRespectsClaim(getPlayer(shooter, serverLevel), world, blockPos)
-                && BlockImmutabilityUtil.canBlockBeDestroyed(world, blockPos)) {
+                && BlockImmutabilityUtil.canBlockBeGrouped(world, blockPos)) {
                 validBlocks.add(blockPos);
             }
         }
@@ -94,15 +93,11 @@ public class SelectEffect extends AbstractEffect {
             return;
         }
         
-        if (!ServerConfig.ALLOW_BLOCK_GROUP_CREATION.get()) {
-            return;
-        }
-        
         java.util.Map<BlockPos, BlockState> capturedStates = new java.util.HashMap<>();
         for (BlockPos pos : blockPositions) {
             if (!level.isOutsideBuildHeight(pos)) {
                 BlockState state = level.getBlockState(pos);
-                if (!state.isAir() && !BlockImmutabilityUtil.isBlockImmutable(state)) {
+                if (BlockImmutabilityUtil.canBlockBeGrouped(level, pos, state)) {
                     capturedStates.put(pos, state);
                 }
             }

--- a/src/main/java/com/github/ars_zero/common/util/BlockImmutabilityUtil.java
+++ b/src/main/java/com/github/ars_zero/common/util/BlockImmutabilityUtil.java
@@ -1,10 +1,12 @@
 package com.github.ars_zero.common.util;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.capabilities.Capabilities;
 
 public class BlockImmutabilityUtil {
     
@@ -46,5 +48,51 @@ public class BlockImmutabilityUtil {
         }
         
         return true;
+    }
+
+    public static boolean canBlockBeGrouped(Level level, BlockPos pos) {
+        if (level.isOutsideBuildHeight(pos)) {
+            return false;
+        }
+        return canBlockBeGrouped(level, pos, level.getBlockState(pos));
+    }
+
+    public static boolean canBlockBeGrouped(Level level, BlockPos pos, BlockState state) {
+        if (level.isOutsideBuildHeight(pos)) {
+            return false;
+        }
+        if (state == null || state.isAir()) {
+            return false;
+        }
+        if (isBlockImmutable(state)) {
+            return false;
+        }
+        if (state.getDestroySpeed(level, pos) < 0.0f) {
+            return false;
+        }
+        if (!state.getFluidState().isEmpty()) {
+            return false;
+        }
+        if (state.hasBlockEntity() || level.getBlockEntity(pos) != null) {
+            return false;
+        }
+        return !hasBlockCapabilities(level, pos);
+    }
+
+    private static boolean hasBlockCapabilities(Level level, BlockPos pos) {
+        for (Direction direction : Direction.values()) {
+            if (level.getCapability(Capabilities.ItemHandler.BLOCK, pos, direction) != null) {
+                return true;
+            }
+            if (level.getCapability(Capabilities.FluidHandler.BLOCK, pos, direction) != null) {
+                return true;
+            }
+            if (level.getCapability(Capabilities.EnergyStorage.BLOCK, pos, direction) != null) {
+                return true;
+            }
+        }
+        return level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null) != null
+            || level.getCapability(Capabilities.FluidHandler.BLOCK, pos, null) != null
+            || level.getCapability(Capabilities.EnergyStorage.BLOCK, pos, null) != null;
     }
 }


### PR DESCRIPTION
Remove the Block Group Entities config, always enabling them, and enforce stricter eligibility for grouped blocks.

The config was removed as per the task, making block groups always enabled. Stricter eligibility checks were added to ensure that only simple, regular blocks (no fluids, block entities, or capabilities) are included in these groups, preventing potential issues with complex blocks when moved.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d600329-457a-4aea-ad88-0fc257f5942d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d600329-457a-4aea-ad88-0fc257f5942d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

