### PR TITLE
Four elements enchantment recipe

### DIFF
--- a/src/main/resources/data/ars_nouveau/tags/items/spellbook.json
+++ b/src/main/resources/data/ars_nouveau/tags/items/spellbook.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "ars_zero:novice_spell_staff",
+    "ars_zero:mage_spell_staff",
+    "ars_zero:archmage_spell_staff",
+    "ars_zero:creative_spell_staff",
+    "ars_zero:spellcasting_circlet"
+  ]
+}


### PR DESCRIPTION
Add Ars Zero spell staffs and Psion's Circlet to the `ars_nouveau:spellbook` tag to enable the 'Protection of the 4 elements' enchantment recipe.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c85534a-a71a-4164-a9f2-409ec0524367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c85534a-a71a-4164-a9f2-409ec0524367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

