### PR TITLE
Fixes Beam issues involving Sable sub-levels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,10 @@ repositories {
         name = "RedlanceMinecraft"
         url = "https://repo.redlance.org/public"
     }
+    maven {
+        name = "RyanHCode Maven"
+        url = "https://maven.ryanhcode.dev/releases"
+    }
     exclusiveContent {
         forRepository {
             maven {
@@ -149,6 +153,12 @@ dependencies {
     compileOnly "curse.maven:jade-324717:5444008"
     
     compileOnly "com.hollingsworth.nuggets:nuggets-neoforge-1.21.1:${nuggets_version}"
+
+    jarJar(api("dev.ryanhcode.sable-companion:sable-companion-common-${project.minecraft_version}") {
+        version {
+            prefer project.sable_companion_version
+        }
+    })
 
     testImplementation("net.neoforged:neoforge:${neo_version}")
     

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,4 @@ nuggets_version=1.1.0.48
 curios_version=9.2.2
 geckolib_version=4.8.3
 patchouli_version=87-NEOFORGE-SNAPSHOT
+sable_companion_version=1.4.2

--- a/src/main/java/com/github/ars_zero/common/entity/EffectBeamEntity.java
+++ b/src/main/java/com/github/ars_zero/common/entity/EffectBeamEntity.java
@@ -1,6 +1,7 @@
 package com.github.ars_zero.common.entity;
 
 import com.github.ars_zero.common.glyph.EffectBeam;
+import com.github.ars_zero.common.util.TurretHelper;
 import com.github.ars_zero.registry.ModEntities;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
@@ -9,6 +10,8 @@ import com.hollingsworth.arsnouveau.api.spell.Spell;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
 import com.hollingsworth.arsnouveau.api.spell.SpellStats;
+import dev.ryanhcode.sable.companion.SableCompanion;
+import net.minecraft.core.Position;
 import org.jetbrains.annotations.Nullable;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import net.minecraft.core.Direction;
@@ -239,7 +242,8 @@ public class EffectBeamEntity extends Entity implements ILifespanExtendable, IMa
         
         if (this.entityData.get(IS_TURRET)) {
             Direction facing = Direction.from3DDataValue(this.entityData.get(TURRET_FACING));
-            lookVec = new Vec3(facing.getStepX(), facing.getStepY(), facing.getStepZ()).normalize();
+            BlockPos turretPos = new BlockPos(this.entityData.get(TURRET_X), this.entityData.get(TURRET_Y), this.entityData.get(TURRET_Z));
+            lookVec = TurretHelper.getTurretLookDir(level, turretPos, facing);
         } else {
             if (this.casterUUID == null) {
                 return;
@@ -250,7 +254,7 @@ public class EffectBeamEntity extends Entity implements ILifespanExtendable, IMa
             }
             lookVec = caster.getLookAngle();
         }
-        
+
         if (lookVec.lengthSqr() >= 1.0E-12) {
             float[] yawPitch = com.github.ars_zero.common.util.MathHelper.vecToYawPitch(lookVec);
             this.setYRot(yawPitch[0]);
@@ -332,7 +336,8 @@ public class EffectBeamEntity extends Entity implements ILifespanExtendable, IMa
     public void tick() {
         super.tick();
 
-        if (!this.level().isClientSide && this.level() instanceof ServerLevel serverLevel) {
+        Level world = this.level();
+        if (!world.isClientSide && world instanceof ServerLevel serverLevel) {
             tickAndSyncDrain(serverLevel);
             if (this.getLifetime() <= 0) {
                 this.discard();
@@ -346,8 +351,8 @@ public class EffectBeamEntity extends Entity implements ILifespanExtendable, IMa
         Vec3 forward = this.getForward();
         Vec3 end = origin.add(forward.scale(RAY_LENGTH + 0.5));
 
-        BlockHitResult blockHit = this.level().clip(new ClipContext(origin, end, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, this));
-        HitResult hitResult = blockHit;
+        BlockHitResult blockHit = world.clip(new ClipContext(origin, end, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, this));
+        HitResult hitResult = blockHit.getType() == HitResult.Type.MISS ? blockHit : new BlockHitResult(SableCompanion.INSTANCE.projectOutOfSubLevel(world, (Position) blockHit.getLocation()), blockHit.getDirection(), blockHit.getBlockPos(), blockHit.isInside());
         if (!this.isIgnoreEntities()) {
             EntityHitResult entityHit = ProjectileUtil.getEntityHitResult(this, origin, end, this.getBoundingBox().inflate(RAY_LENGTH), e -> e.isPickable() && !e.isSpectator() && e != this, RAY_LENGTH * RAY_LENGTH);
             if (entityHit != null) {

--- a/src/main/java/com/github/ars_zero/common/glyph/AnchorEffect.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/AnchorEffect.java
@@ -12,6 +12,8 @@ import com.github.ars_zero.common.spell.SpellEffectType;
 import com.github.ars_zero.common.spell.SpellResult;
 import com.github.ars_zero.common.spell.MultiPhaseCastContext;
 import com.github.ars_zero.common.util.BlockImmutabilityUtil;
+import com.github.ars_zero.common.util.MathHelper;
+import com.github.ars_zero.common.util.TurretHelper;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
@@ -21,12 +23,16 @@ import com.hollingsworth.arsnouveau.api.spell.SpellTier;
 import com.hollingsworth.arsnouveau.api.spell.SpellSchools;
 import com.hollingsworth.arsnouveau.api.spell.SpellSchool;
 import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.LivingCaster;
+import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.TileCaster;
+import com.hollingsworth.arsnouveau.common.block.BasicSpellTurret;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtract;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSensitive;
+import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Position;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
@@ -61,8 +67,45 @@ public class AnchorEffect extends AbstractEffect {
     public static final String ID = "anchor_effect";
     public static final AnchorEffect INSTANCE = new AnchorEffect();
 
+    private record RepositionResult(float yaw, float pitch, Vec3 newPosition) {}
+
     public AnchorEffect() {
         super(ArsZero.prefix(ID), "Anchor");
+    }
+
+    private static RepositionResult getRepositionResult(ServerLevel world, SpellStats spellStats, Player player, SpellResult beginResult, SpellContext baseCastContext, MultiPhaseCastContext multiphaseCastContext) {
+        boolean isSensitive = spellStats.hasBuff(AugmentSensitive.INSTANCE);
+        float yaw = player.getYRot();
+        float pitch = player.getXRot();
+        Vec3 casterPos = player.getEyePosition(1.0f);
+        if(isSensitive) {
+            yaw = beginResult.casterYaw;
+            pitch = beginResult.casterPitch;
+            if(beginResult.casterPosition != null)
+                casterPos = beginResult.casterPosition;
+        }
+        else if (baseCastContext.getCaster().getCasterType() == SpellContext.CasterType.TURRET && baseCastContext.getCaster() instanceof TileCaster tileCaster) {
+            float[] yawPitch = MathHelper.vecToYawPitch(TurretHelper.getTurretLookDir(world, tileCaster.getTile().getBlockPos(), tileCaster.getFacingDirection()));
+            yaw = yawPitch[0];
+            pitch = yawPitch[1];
+            casterPos = SableCompanion.INSTANCE.projectOutOfSubLevel(world, BasicSpellTurret.getDispensePosition(tileCaster.getTile().getBlockPos(), tileCaster.getFacingDirection()));
+        } else if (player instanceof FakePlayer) {
+            BlockPos shooterBlock = BlockPos.containing(player.position());
+            TurretHelper.TurretAim aim = TurretHelper.findTurretAim(world, shooterBlock);
+            if (aim != null) {
+                Position dispensePos = BasicSpellTurret.getDispensePosition(aim.turretPos(), aim.facing());
+                float[] yawPitch = MathHelper.vecToYawPitch(TurretHelper.getTurretLookDir(world, aim.turretPos(), aim.facing()));
+                yaw = yawPitch[0];
+                pitch = yawPitch[1];
+                casterPos = SableCompanion.INSTANCE.projectOutOfSubLevel(world, dispensePos);
+            }
+        }
+        Vec3 newPosition = beginResult.transformLocalToWorld(
+                yaw,
+                pitch,
+                casterPos,
+                multiphaseCastContext.distanceMultiplier);
+        return new RepositionResult(yaw, pitch, newPosition);
     }
 
     @Override
@@ -121,20 +164,10 @@ public class AnchorEffect extends AbstractEffect {
                 }
             }
 
-            boolean isSensitive = spellStats.hasBuff(AugmentSensitive.INSTANCE);
-            boolean useStoredCasterInfo = isSensitive || player instanceof FakePlayer;
-            float yaw = useStoredCasterInfo ? beginResult.casterYaw : player.getYRot();
-            float pitch = useStoredCasterInfo ? beginResult.casterPitch : player.getXRot();
-            Vec3 casterPos = useStoredCasterInfo && beginResult.casterPosition != null
-                    ? beginResult.casterPosition
-                    : player.getEyePosition(1.0f);
-
-            Vec3 newPosition = beginResult.transformLocalToWorld(
-                    yaw,
-                    pitch,
-                    casterPos,
-                    castContext.distanceMultiplier);
-
+            RepositionResult result = getRepositionResult(serverLevel, spellStats, player, beginResult, spellContext, castContext);
+            Vec3 newPosition = result.newPosition();
+            float yaw = result.yaw();
+            float pitch = result.pitch();
             if (newPosition != null && canMoveToPosition(newPosition, world, target)) {
                 if (target instanceof ServerPlayer targetPlayer) {
                     targetPlayer.teleportTo(newPosition.x, newPosition.y, newPosition.z);
@@ -321,6 +354,8 @@ public class AnchorEffect extends AbstractEffect {
             return;
         if (!(shooter instanceof Player player))
             return;
+        if (!(world instanceof ServerLevel serverLevel))
+            return;
 
         IMultiPhaseCaster caster = IMultiPhaseCaster.from(spellContext, shooter);
         if (caster == null) {
@@ -336,19 +371,8 @@ public class AnchorEffect extends AbstractEffect {
             if (beginResult.blockGroup != null && beginResult.relativeOffset != null) {
                 BlockGroupEntity blockGroup = beginResult.blockGroup;
 
-                boolean isSensitive = spellStats.hasBuff(AugmentSensitive.INSTANCE);
-                boolean useStoredCasterInfo = isSensitive || player instanceof FakePlayer;
-                float yaw = useStoredCasterInfo ? beginResult.casterYaw : player.getYRot();
-                float pitch = useStoredCasterInfo ? beginResult.casterPitch : player.getXRot();
-                Vec3 casterPos = useStoredCasterInfo && beginResult.casterPosition != null
-                        ? beginResult.casterPosition
-                        : player.getEyePosition(1.0f);
-
-                Vec3 newPosition = beginResult.transformLocalToWorld(
-                        yaw,
-                        pitch,
-                        casterPos,
-                        castContext.distanceMultiplier);
+                RepositionResult repositionResult = getRepositionResult(serverLevel, spellStats, player, beginResult, spellContext, castContext);
+                Vec3 newPosition = repositionResult.newPosition();
 
                 if (newPosition != null && canMoveToPosition(newPosition, world, blockGroup)) {
                     blockGroup.setPos(newPosition.x, newPosition.y, newPosition.z);

--- a/src/main/java/com/github/ars_zero/common/glyph/EffectBeam.java
+++ b/src/main/java/com/github/ars_zero/common/glyph/EffectBeam.java
@@ -7,6 +7,7 @@ import com.github.ars_zero.common.spell.MultiPhaseCastContext;
 import com.github.ars_zero.common.spell.SpellEffectType;
 import com.github.ars_zero.common.spell.SpellResult;
 import com.github.ars_zero.common.util.MathHelper;
+import com.github.ars_zero.common.util.TurretHelper;
 import com.github.ars_zero.registry.ModParticleTimelines;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
@@ -24,9 +25,10 @@ import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSensitive;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSplit;
 import com.hollingsworth.arsnouveau.common.block.BasicSpellTurret;
+import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.core.Position;
 import net.neoforged.neoforge.common.util.FakePlayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -46,8 +48,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class EffectBeam extends AbstractEffect {
-
-    private record TurretAim(BlockPos turretPos, Direction facing) {}
 
     public static final String ID = "effect_beam";
     public static final EffectBeam INSTANCE = new EffectBeam();
@@ -97,34 +97,16 @@ public class EffectBeam extends AbstractEffect {
         return BEAM_AMPLIFY_DAMAGE_BONUS.get().floatValue();
     }
 
-    private static TurretAim findTurretAim(ServerLevel level, BlockPos playerBlock) {
-        BlockState atPlayer = level.getBlockState(playerBlock);
-        if (atPlayer.getBlock() instanceof BasicSpellTurret) {
-            return new TurretAim(playerBlock, atPlayer.getValue(BasicSpellTurret.FACING));
-        }
-        for (Direction dir : Direction.values()) {
-            BlockPos neighbor = playerBlock.relative(dir);
-            BlockState state = level.getBlockState(neighbor);
-            if (state.getBlock() instanceof BasicSpellTurret) {
-                Direction facing = state.getValue(BasicSpellTurret.FACING);
-                if (neighbor.relative(facing).equals(playerBlock)) {
-                    return new TurretAim(neighbor, facing);
-                }
-            }
-        }
-        return null;
-    }
-
     private static Vec3 getBeamAimTarget(Level world, LivingEntity shooter, SpellContext spellContext) {
         Vec3 eyePos;
         Vec3 lookVec;
         if (shooter instanceof FakePlayer && world instanceof ServerLevel serverLevel) {
             BlockPos shooterBlock = BlockPos.containing(shooter.position());
-            TurretAim aim = findTurretAim(serverLevel, shooterBlock);
+            TurretHelper.TurretAim aim = TurretHelper.findTurretAim(serverLevel, shooterBlock);
             if (aim != null) {
-                var dispensePos = BasicSpellTurret.getDispensePosition(aim.turretPos, aim.facing);
+                var dispensePos = BasicSpellTurret.getDispensePosition(aim.turretPos(), aim.facing());
                 eyePos = new Vec3(dispensePos.x(), dispensePos.y(), dispensePos.z());
-                lookVec = new Vec3(aim.facing.getStepX(), aim.facing.getStepY(), aim.facing.getStepZ()).normalize();
+                lookVec = new Vec3(aim.facing().getStepX(), aim.facing().getStepY(), aim.facing().getStepZ()).normalize();
             } else {
                 eyePos = shooter.getEyePosition(1.0f);
                 lookVec = shooter.getLookAngle();
@@ -142,7 +124,7 @@ public class EffectBeam extends AbstractEffect {
             double blockDist = blockHit.getType() == HitResult.Type.MISS ? Double.MAX_VALUE : eyePos.distanceTo(blockHit.getLocation());
             return entityDist < blockDist ? entityHit.getLocation() : (blockHit.getType() == HitResult.Type.MISS ? lookEnd : blockHit.getLocation());
         }
-        return blockHit.getType() == HitResult.Type.MISS ? lookEnd : blockHit.getLocation();
+        return blockHit.getType() == HitResult.Type.MISS ? lookEnd : SableCompanion.INSTANCE.projectOutOfSubLevel(world, (Position) blockHit.getLocation());
     }
 
     @Override
@@ -151,7 +133,7 @@ public class EffectBeam extends AbstractEffect {
             return;
         }
 
-        Vec3 pos = safelyGetHitPos(rayTraceResult);
+        Vec3 pos = SableCompanion.INSTANCE.projectOutOfSubLevel(world, (Position) safelyGetHitPos(rayTraceResult));
         Vec3 lookVec;
         BlockPos turretPos = null;
         Direction turretFacing = null;
@@ -159,14 +141,14 @@ public class EffectBeam extends AbstractEffect {
         if (spellContext.getCaster().getCasterType() == SpellContext.CasterType.TURRET && spellContext.getCaster() instanceof com.hollingsworth.arsnouveau.api.spell.wrapped_caster.TileCaster tileCaster) {
             turretPos = tileCaster.getTile().getBlockPos();
             turretFacing = tileCaster.getFacingDirection();
-            lookVec = new Vec3(turretFacing.getStepX(), turretFacing.getStepY(), turretFacing.getStepZ()).normalize();
+            lookVec = TurretHelper.getTurretLookDir(world, turretPos, turretFacing);
         } else if (shooter instanceof FakePlayer && serverLevel != null) {
             BlockPos shooterBlock = BlockPos.containing(shooter.position());
-            TurretAim aim = findTurretAim(serverLevel, shooterBlock);
+            TurretHelper.TurretAim aim = TurretHelper.findTurretAim(serverLevel, shooterBlock);
             if (aim != null) {
-                turretPos = aim.turretPos;
-                turretFacing = aim.facing;
-                lookVec = new Vec3(aim.facing.getStepX(), aim.facing.getStepY(), aim.facing.getStepZ()).normalize();
+                turretPos = aim.turretPos();
+                turretFacing = aim.facing();
+                lookVec = TurretHelper.getTurretLookDir(world, turretPos, turretFacing);
             } else {
                 lookVec = shooter.getLookAngle();
             }

--- a/src/main/java/com/github/ars_zero/common/spell/SpellResult.java
+++ b/src/main/java/com/github/ars_zero/common/spell/SpellResult.java
@@ -1,13 +1,19 @@
 package com.github.ars_zero.common.spell;
 
 import com.github.ars_zero.common.entity.BlockGroupEntity;
+import com.github.ars_zero.common.util.MathHelper;
+import com.github.ars_zero.common.util.TurretHelper;
 import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.IWrappedCaster;
 import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.LivingCaster;
 import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.TileCaster;
+import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Position;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -112,10 +118,13 @@ public class SpellResult {
             yaw = living.getYRot();
             pitch = living.getXRot();
         } else if (caster instanceof TileCaster tileCaster) {
-            position = tileCaster.getPosition().add(0.5, 0.5, 0.5);
-            Direction facing = tileCaster.getFacingDirection();
-            yaw = directionToYaw(facing);
-            pitch = directionToPitch(facing);
+            BlockEntity tile = tileCaster.getTile();
+            BlockPos tilePos = tile.getBlockPos();
+            Level tileLevel = tile.getLevel();
+            position = SableCompanion.INSTANCE.projectOutOfSubLevel(tileLevel, (Position) tileCaster.getPosition().add(0.5, 0.5, 0.5));
+            float[] yawPitch = MathHelper.vecToYawPitch(TurretHelper.getTurretLookDir(tileLevel, tilePos, tileCaster.getFacingDirection()));
+            yaw = yawPitch[0];
+            pitch = yawPitch[1];
         } else {
             position = caster.getPosition();
         }

--- a/src/main/java/com/github/ars_zero/common/util/TurretHelper.java
+++ b/src/main/java/com/github/ars_zero/common/util/TurretHelper.java
@@ -1,0 +1,42 @@
+package com.github.ars_zero.common.util;
+
+import com.hollingsworth.arsnouveau.common.block.BasicSpellTurret;
+import dev.ryanhcode.sable.companion.SableCompanion;
+import dev.ryanhcode.sable.companion.SubLevelAccess;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+
+public class TurretHelper {
+
+    public record TurretAim(BlockPos turretPos, Direction facing) {}
+
+    public static TurretAim findTurretAim(ServerLevel level, BlockPos playerBlock) {
+        BlockState atPlayer = level.getBlockState(playerBlock);
+        if (atPlayer.getBlock() instanceof BasicSpellTurret) {
+            return new TurretAim(playerBlock, atPlayer.getValue(BasicSpellTurret.FACING));
+        }
+        for (Direction dir : Direction.values()) {
+            BlockPos neighbor = playerBlock.relative(dir);
+            BlockState state = level.getBlockState(neighbor);
+            if (state.getBlock() instanceof BasicSpellTurret) {
+                Direction facing = state.getValue(BasicSpellTurret.FACING);
+                if (neighbor.relative(facing).equals(playerBlock)) {
+                    return new TurretAim(neighbor, facing);
+                }
+            }
+        }
+        return null;
+    }
+
+    public static Vec3 getTurretLookDir(Level world, BlockPos turretPos, Direction turretFacing) {
+        Vec3 lookVec = new Vec3(turretFacing.getStepX(), turretFacing.getStepY(), turretFacing.getStepZ()).normalize();
+        if(SableCompanion.INSTANCE.getContaining(world, turretPos) instanceof SubLevelAccess subLevel) {
+            return subLevel.logicalPose().transformNormal(lookVec).normalize();
+        }
+        return lookVec;
+    }
+}


### PR DESCRIPTION
Fixes #85 by projecting the look vector and hit position of beams out of sub-level space. This involves adding [Sable Companion](https://github.com/ryanhcode/sable-companion) as a Jar-in-Jar dependency. Sable does not need to be enabled to use Sable Companion.