### PR TITLE
Add CurseForge publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,20 @@ name: Publish on CurseForge
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      "*"
+    inputs:
+      bump_type:
+        description: 'Version bump type (ignored when bumping beta of an existing beta)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      is_beta:
+        description: 'Beta release — if current is beta: +1 to beta number; if current is release: start X.(minor+1).0-beta1'
+        required: false
+        type: boolean
+        default: false
 
 env:
   MC_MIN_VER: '1.21'
@@ -15,20 +26,75 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 20
-      - name: Fetch tags (actions/checkout#1467)
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags --force
+      - name: Compute new version
         run: |
-          git fetch --tags --force
-      - name: Get version from tag
+          CURRENT=$(grep "^mod_version=" gradle.properties | cut -d= -f2)
+          echo "Current version: $CURRENT"
+
+          if [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-beta([0-9]+)$ ]]; then
+            IS_CURRENT_BETA=true
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            BETA="${BASH_REMATCH[4]}"
+          elif [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            IS_CURRENT_BETA=false
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            BETA=0
+          else
+            echo "Unrecognized version format: $CURRENT" && exit 1
+          fi
+
+          if [[ "${{ inputs.is_beta }}" == "true" ]]; then
+            if [[ "$IS_CURRENT_BETA" == "true" ]]; then
+              NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-beta$((BETA + 1))"
+            else
+              NEW_VERSION="${MAJOR}.$((MINOR + 1)).0-beta1"
+            fi
+          else
+            case "${{ inputs.bump_type }}" in
+              patch) NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+              minor) NEW_VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+              major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+            esac
+          fi
+
+          echo "New version: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+      - name: Generate changelog
         run: |
-          echo "VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [[ -n "$PREV_TAG" ]]; then
+            LOG=$(git log "${PREV_TAG}..HEAD" --oneline)
+          else
+            LOG=$(git log HEAD --oneline)
+          fi
+          printf "Auto-generated Changelog:\n%s" "$(echo "$LOG" | awk '! / (ci|ver|internal|README)!?([:,. ]|$)/ { $1="-"; print $0 }')" > .ci-changelog.md
+          cat .ci-changelog.md
+      - name: Update gradle.properties
+        run: |
+          sed -i "s/^mod_version=.*/mod_version=${{ env.NEW_VERSION }}/" gradle.properties
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add gradle.properties
+          git commit -m "ver: ${{ env.NEW_VERSION }}"
+          git tag "${{ env.NEW_VERSION }}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "${{ env.NEW_VERSION }}"
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
@@ -42,16 +108,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
         run: ./gradlew build --no-daemon
-      - name: Generate changelog
-        run: |
-          printf "Auto-generated Changelog:\n%s" "$(git log "$(git describe --tags --abbrev=0 HEAD~1)..HEAD" --oneline | awk '! / (ci|ver|internal|README)!?([:,. ]|$)/ { $1="-"; print $0 }')" > .ci-changelog.md
-          cat .ci-changelog.md
       - uses: Kir-Antipov/mc-publish@v3.3
         with:
           curseforge-id: 1377482
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
-          name: Ars Zero ${{ env.VERSION }} for ${{ env.MC_MAX_VER }}
-          version: ${{ env.VERSION }}
+          name: Ars Zero ${{ env.NEW_VERSION }} for ${{ env.MC_MAX_VER }}
+          version: ${{ env.NEW_VERSION }}
           game-versions: |
             >=${{ env.MC_MIN_VER }} <=${{ env.MC_MAX_VER }}
           changelog-file: .ci-changelog.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish on CurseForge
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      "*"
+
+env:
+  MC_MIN_VER: '1.21'
+  MC_MAX_VER: '1.21.1'
+  JAVA_VERSION: 21
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 20
+      - name: Fetch tags (actions/checkout#1467)
+        run: |
+          git fetch --tags --force
+      - name: Get version from tag
+        run: |
+          echo "VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: "temurin"
+          cache: gradle
+          cache-dependency-path: |
+            *.gradle*
+            gradle/wrapper/gradle-wrapper.properties
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build with Gradle
+        run: ./gradlew build --no-daemon
+      - name: Generate changelog
+        run: |
+          printf "Auto-generated Changelog:\n%s" "$(git log "$(git describe --tags --abbrev=0 HEAD~1)..HEAD" --oneline | awk '! / (ci|ver|internal|README)!?([:,. ]|$)/ { $1="-"; print $0 }')" > .ci-changelog.md
+          cat .ci-changelog.md
+      - uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          curseforge-id: 1377482
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          name: Ars Zero ${{ env.VERSION }} for ${{ env.MC_MAX_VER }}
+          version: ${{ env.VERSION }}
+          game-versions: |
+            >=${{ env.MC_MIN_VER }} <=${{ env.MC_MAX_VER }}
+          changelog-file: .ci-changelog.md

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,30 @@
+name: Quality
+
+on:
+  pull_request:
+
+env:
+  JAVA_VERSION: 21
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: "temurin"
+          cache: gradle
+          cache-dependency-path: |
+            *.gradle*
+            gradle/wrapper/gradle-wrapper.properties
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Checkstyle
+        run: ./gradlew checkstyleMain --no-daemon
+      - name: Build (no tests)
+        run: ./gradlew build -x test -x checkstyleMain --no-daemon


### PR DESCRIPTION
Triggers on tag push or manual dispatch; builds with Gradle, generates
a filtered git-log changelog, and publishes to CurseForge project 1377482.

https://claude.ai/code/session_016RTy5Ayy7kBrcYyfZDpizL